### PR TITLE
frontend: use custom svg icon to represent sailbots on the map

### DIFF
--- a/dotbot/frontend/src/DotBots.js
+++ b/dotbot/frontend/src/DotBots.js
@@ -109,6 +109,12 @@ const SailBotItem = (props) => {
   const [ rudderValue, setRudderValue ] = useState(0);
   const [ sailValue, setSailValue ] = useState(0);
   const [ active, setActive ] = useState(true);
+  const [ color, setColor ] = useState({ r: 0, g: 0, b: 0 });
+
+  const applyColor = async () => {
+    await apiUpdateRgbLed(props.dotbot.address, props.dotbot.application, color.r, color.g, color.b);
+    await props.refresh();
+  }
 
   const rudderUpdate = async (event) => {
     const newRudderValue = parseInt(event.target.value);
@@ -128,6 +134,14 @@ const SailBotItem = (props) => {
     }
     await apiUpdateMoveRaw(props.dotbot.address, props.dotbot.application, rudderValue, 0, 0, sailValue).catch(error => console.log(error));
   }, active ? 100 : null);
+
+  useEffect(() => {
+    if (props.dotbot.rgb_led) {
+      setColor({ r: props.dotbot.rgb_led.red, g: props.dotbot.rgb_led.green, b: props.dotbot.rgb_led.blue })
+    } else {
+      setColor({ r: 0, g: 0, b: 0 })
+    }
+  }, [props.dotbot.rgb_led, setColor]);
 
   return (
     <div className="accordion-item">
@@ -158,6 +172,16 @@ const SailBotItem = (props) => {
             <div className="mx-auto justify-content-center">
               <p>{`Sail: ${sailValue}`}</p>
               <input type="range" min="-128" max="127" defaultValue={sailValue} onChange={sailUpdate}/>
+            </div>
+          </div>
+          <div className="d-flex justify-content-center">
+            <div className="mx-auto justify-content-center">
+              <RgbColorPicker color={color} onChange={setColor} />
+            </div>
+          </div>
+          <div className="d-flex justify-content-center">
+            <div className="mx-auto justify-content-center">
+              <button className="btn btn-primary m-1" onClick={applyColor}>Apply color</button>
             </div>
           </div>
         </div>
@@ -293,10 +317,10 @@ const DotBots = () => {
         </div>
         <div className="col col-xxl-6">
           <div className="d-block d-md-none m-1">
-            <SailBotsMap sailbots={dotbots.filter(dotbot => dotbot.application === ApplicationType.SailBot)} mapSize={350} />
+            <SailBotsMap sailbots={dotbots.filter(dotbot => dotbot.application === ApplicationType.SailBot)} active={activeDotbot} mapSize={350} />
           </div>
           <div className="d-none d-md-block m-1">
-            <SailBotsMap sailbots={dotbots.filter(dotbot => dotbot.application === ApplicationType.SailBot)} mapSize={650} />
+            <SailBotsMap sailbots={dotbots.filter(dotbot => dotbot.application === ApplicationType.SailBot)} active={activeDotbot} mapSize={650} />
           </div>
         </div>
       </div>

--- a/dotbot/frontend/src/SailBotsMap.js
+++ b/dotbot/frontend/src/SailBotsMap.js
@@ -2,9 +2,50 @@ import React from "react";
 
 import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
 
+import L from "leaflet";
+
 const defaultPosition = [
   48.832313766146896, 2.4126897594949184
 ];
+
+export const SailBotMarker = (props) => {
+
+  let rgbColor = "rgb(0, 0, 0)"
+  if (props.sailbot.rgb_led) {
+    rgbColor = `rgb(${props.sailbot.rgb_led.red}, ${props.sailbot.rgb_led.green}, ${props.sailbot.rgb_led.blue})`
+  }
+
+  let boatStroke = "none";
+  if (props.sailbot.address === props.active) {
+    boatStroke = "black";
+  }
+
+  const svgIcon = L.divIcon({
+    html: `
+      <svg
+        width="30"
+        height="50"
+        viewBox="0 0 45 75"
+        version="1.1"
+        preserveAspectRatio="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+      <g>
+        <path d="M 0 10 C 0 20 0 40 10 50 C 20 40 20 20 20 10 C 20 0 0 0 0 10" stroke="${boatStroke}" strokeWidth="1" opacity="80%" fill="${rgbColor}" />
+        <path d="M 10 30 C 20 30 30 30 30 20" stroke="blue" strokeWidth="2" opacity="80%" fill="none" />
+      </g>
+      </svg>`,
+    className: "",
+    iconSize: [30, 50],
+    iconAnchor: [10, 10],
+  });
+
+  return (
+    <Marker key={props.sailbot.address} icon={svgIcon} position={[props.sailbot.gps_position.latitude, props.sailbot.gps_position.longitude]} opacity={`${props.sailbot.status === 0 ? "1" : "0.4"}`}>
+      <Popup>{`SailBot@${props.sailbot.address}`}</Popup>
+    </Marker>
+  );
+};
 
 export const SailBotsMap = (props) => {
 
@@ -23,12 +64,7 @@ export const SailBotsMap = (props) => {
               props.sailbots
                 .filter(sailbot => sailbot.gps_position)
                 .filter(sailbot => sailbot.status !== 2)
-                .map(
-                  sailbot => (
-                  <Marker key={sailbot.address} position={[sailbot.gps_position.latitude, sailbot.gps_position.longitude]} opacity={`${sailbot.status === 0 ? "1" : "0.4"}`}>
-                    <Popup>{`SailBot@${sailbot.address}`}</Popup>
-                  </Marker>)
-                )
+                .map(sailbot => <SailBotMarker key={sailbot.address} sailbot={sailbot} active={props.active} />)
             }
           </MapContainer>
         </div>


### PR DESCRIPTION
This PR also adds a color picker element in each sailbot item to set the color of the icon.
A border is displayed around the icon when the sailbot is active, e.g controllable with a joystick.

fixes #44 