### PR TITLE
logger: add module for storing runtime logs in a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.gz
 *.whl
 *.orig
+*.log
 *.egg-info/
 .coverage
 .tox/

--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ Options:
   -s, --swarm-id TEXT             Swarm ID in hex. Defaults to 0000
   -w, --webbrowser                Open a web browser automatically
   -T, --table                     Display table in terminal
-  -v, --verbose                   Run in verbose mode (all payloads received are
-                                  printed in terminal)
+  -v, --verbose                   Run in verbose mode (all payloads received
+                                  are printed in terminal)
+  --log-level [debug|info|warning|error]
+                                  Logging level. Defaults to info
+  --log-output PATH               Filename where logs are redirected
   --help                          Show this message and exit.
 ```
 

--- a/dotbot/hdlc.py
+++ b/dotbot/hdlc.py
@@ -2,6 +2,8 @@
 
 from enum import Enum
 
+from dotbot.logger import LOGGER
+
 
 HDLC_FLAG = b"\x7E"
 HDLC_FLAG_ESCAPED = b"\x5E"
@@ -179,12 +181,12 @@ class HDLCState(Enum):
 class HDLCHandler:
     """Handles the reception of an HDLC frame byte by byte."""
 
-    def __init__(self, verbose: bool = False):
+    def __init__(self):
         self.state = HDLCState.IDLE
         self.fcs = HDLC_FCS_INIT
         self.output = bytearray()
         self.escape_byte = False
-        self.verbose = verbose
+        self._logger = LOGGER.bind(context=__name__)
 
     @property
     def payload(self):
@@ -194,12 +196,10 @@ class HDLCHandler:
 
         self.state = HDLCState.IDLE
         if len(self.output) < 2:
-            if self.verbose is True:
-                print("Invalid payload")
+            self._logger.error("Invalid payload")
             return bytearray()
         if self.fcs != HDLC_FCS_OK:
-            if self.verbose is True:
-                print("Invalid FCS")
+            self._logger.error("Invalid FCS")
             return bytearray()
         self.fcs = HDLC_FCS_INIT
         return self.output[:-2]

--- a/dotbot/joystick.py
+++ b/dotbot/joystick.py
@@ -36,6 +36,8 @@ class JoystickController(ControllerBase):
                 f"Not enough axes on your joystick. {num_axes} found, expected at least {JOYSTICK_AXIS_COUNT}."
             )
         self.previous_positions = NULL_POSITION
+        self.logger = self.logger.bind(controller_type="joystick", context=__name__)
+        self.logger.info("Controller initialized", num_axes=num_axes)
 
     def pos_from_joystick(self):
         """Fetch positions of the joystick."""
@@ -65,5 +67,6 @@ class JoystickController(ControllerBase):
                         CommandMoveRaw(*positions),
                     )
                 )
+                self.logger.info(keyboard_event="move", positions=positions)
             self.previous_positions = positions
             await asyncio.sleep(REFRESH_PERIOD)  # 50ms delay between each update

--- a/dotbot/keyboard.py
+++ b/dotbot/keyboard.py
@@ -21,6 +21,7 @@ from dotbot.protocol import (
     CommandRgbLed,
 )
 from dotbot.controller import ControllerBase
+from dotbot.logger import LOGGER
 
 
 DIR_KEYS = [
@@ -103,6 +104,8 @@ class KeyboardController(ControllerBase):
         self.previous_speeds = (0, 0)
         self.active_keys = []
         self.event_queue = asyncio.Queue()
+        self._logger = LOGGER.bind(context=__name__)
+        self._logger.info("Controller initialized")
 
     async def update_active_keys(self):
         """Coroutine used to handle keyboard events asynchronously."""
@@ -116,6 +119,7 @@ class KeyboardController(ControllerBase):
                 self.event_queue.put_nowait,
                 KeyboardEvent(KeyboardEventType.PRESSED, key),
             )
+            self._logger.debug("key pressed", key=key)
 
         def on_release(key):
             """Callback called on each keyboard key release event."""
@@ -125,6 +129,7 @@ class KeyboardController(ControllerBase):
                 self.event_queue.put_nowait,
                 KeyboardEvent(KeyboardEventType.RELEASED, key),
             )
+            self._logger.debug("key released", key=key)
 
         listener = keyboard.Listener(on_press=on_press, on_release=on_release)
         listener.start()
@@ -143,6 +148,7 @@ class KeyboardController(ControllerBase):
                             CommandRgbLed(red, green, blue),
                         )
                     )
+                    self._logger.info("color pressed", red=red, green=green, blue=blue)
                     continue
                 self.active_keys.append(event.key)
             self.refresh_speeds()
@@ -196,6 +202,7 @@ class KeyboardController(ControllerBase):
                     CommandMoveRaw(0, left_speed, 0, right_speed),
                 )
             )
+            self._logger.info("refresh speeds", left=left_speed, right=right_speed)
         # pylint: disable=attribute-defined-outside-init
         self.previous_speeds = (left_speed, right_speed)
 

--- a/dotbot/logger.py
+++ b/dotbot/logger.py
@@ -12,21 +12,63 @@ LOG_LEVEL_MAP = {
 }
 
 
-def setup_logging(filename, level):
+def setup_logging(filename, level, handlers):
     """Setup logging."""
-    logging.basicConfig(
-        filename=filename, format="", encoding="utf-8", level=LOG_LEVEL_MAP[level]
-    )
+    processors = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+    ]
+
     structlog.configure(
-        processors=[
-            structlog.stdlib.add_log_level,
-            structlog.processors.TimeStamper(fmt=None),
-            structlog.processors.LogfmtRenderer(
-                key_order=["timestamp", "level", "event"]
-            ),
-            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-        ],
+        processors=processors,
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,
     )
+
+    stdlib_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "logfmt": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processor": structlog.processors.LogfmtRenderer(
+                    key_order=["timestamp", "level", "logger", "event"],
+                    drop_missing=True,
+                ),
+            },
+            "rich": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processor": structlog.dev.ConsoleRenderer(),
+            },
+        },
+        "handlers": {
+            "console": {
+                "formatter": "rich",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stderr",
+            },
+            "file": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "formatter": "logfmt",
+                "filename": filename,
+                "encoding": "utf-8",
+            },
+        },
+        "loggers": {
+            "pydotbot": {
+                "handlers": handlers,
+                "level": LOG_LEVEL_MAP[level],
+                "propagate": True,
+            },
+        },
+    }
+    logging.config.dictConfig(stdlib_config)
+
+
+LOGGER = structlog.get_logger("pydotbot")

--- a/dotbot/logger.py
+++ b/dotbot/logger.py
@@ -1,0 +1,32 @@
+"""Logger module."""
+
+import logging
+import structlog
+
+
+LOG_LEVEL_MAP = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+}
+
+
+def setup_logging(filename, level):
+    """Setup logging."""
+    logging.basicConfig(
+        filename=filename, format="", encoding="utf-8", level=LOG_LEVEL_MAP[level]
+    )
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.processors.TimeStamper(fmt=None),
+            structlog.processors.LogfmtRenderer(
+                key_order=["timestamp", "level", "event"]
+            ),
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )

--- a/dotbot/main.py
+++ b/dotbot/main.py
@@ -25,6 +25,7 @@ from dotbot.controller import (
 )
 from dotbot.keyboard import KeyboardController
 from dotbot.joystick import JoystickController
+from dotbot.logger import setup_logging
 
 
 CONTROLLER_TYPE_DEFAULT = "keyboard"
@@ -127,6 +128,8 @@ def main(
     # welcome sentence
     print(f"Welcome to the DotBots controller (version: {pydotbot_version()}).")
 
+    handlers = ["console", "file"] if table is False else ["file"]
+    setup_logging(log_output, log_level, handlers)
     for controller, controller_cls in DEFAULT_CONTROLLERS.items():
         register_controller(controller, controller_cls)
     try:
@@ -141,8 +144,6 @@ def main(
                 webbrowser,
                 table,
                 verbose,
-                log_level,
-                log_output,
             ),
         )
         asyncio.run(controller.run())

--- a/dotbot/main.py
+++ b/dotbot/main.py
@@ -2,6 +2,7 @@
 
 """Main module of the Dotbot controller command line tool."""
 
+import os
 import sys
 import asyncio
 
@@ -97,6 +98,18 @@ DEFAULT_CONTROLLERS = {
     default=False,
     help="Run in verbose mode (all payloads received are printed in terminal)",
 )
+@click.option(
+    "--log-level",
+    type=click.Choice(["debug", "info", "warning", "error"]),
+    default="info",
+    help="Logging level. Defaults to info",
+)
+@click.option(
+    "--log-output",
+    type=click.Path(),
+    default=os.path.join(os.getcwd(), "pydotbot.log"),
+    help="Filename where logs are redirected",
+)
 def main(
     type,
     port,
@@ -107,6 +120,8 @@ def main(
     webbrowser,
     table,
     verbose,
+    log_level,
+    log_output,
 ):  # pylint: disable=redefined-builtin,too-many-arguments
     """BotController, universal SailBot and DotBot controller."""
     # welcome sentence
@@ -126,6 +141,8 @@ def main(
                 webbrowser,
                 table,
                 verbose,
+                log_level,
+                log_output,
             ),
         )
         asyncio.run(controller.run())

--- a/dotbot/protocol.py
+++ b/dotbot/protocol.py
@@ -101,7 +101,7 @@ class ProtocolHeader(ProtocolData):
             int.from_bytes(bytes_[0:8], "big"),  # destination
             int.from_bytes(bytes_[8:16], "big"),  # source
             int.from_bytes(bytes_[16:18], "big"),  # swarm_id
-            int.from_bytes(bytes_[18:19], "big"),  # application
+            ApplicationType(int.from_bytes(bytes_[18:19], "big")),  # application
             int.from_bytes(bytes_[19:20], "big"),  # version
         )
 

--- a/dotbot/server.py
+++ b/dotbot/server.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from dotbot import pydotbot_version
+from dotbot.logger import LOGGER
 from dotbot.models import (
     DotBotCalibrationStateModel,
     DotBotModel,
@@ -312,12 +313,15 @@ async def websocket_endpoint(websocket: WebSocket):
 
 async def web(controller):
     """Starts the web server application."""
+    logger = LOGGER.bind(context=__name__)
     app.controller = controller
     config = uvicorn.Config(app, port=8000, log_level="warning")
     server = uvicorn.Server(config)
     try:
+        logger.info("Starting web server")
         await server.serve()
     except asyncio.exceptions.CancelledError:
-        print("Web server cancelled")
+        logger.info("Web server cancelled")
     else:
+        logger.info("Stopping web server")
         raise SystemExit()

--- a/dotbot/tests/test_hdlc_handler.py
+++ b/dotbot/tests/test_hdlc_handler.py
@@ -52,7 +52,7 @@ def test_hdlc_handler_decode_with_flags():
 
 
 def test_hdlc_handler_invalid_state():
-    handler = HDLCHandler(verbose=True)
+    handler = HDLCHandler()
     for byte in b"~test\x42\x42":
         handler.handle_byte(int(byte).to_bytes(1, "little"))
     with pytest.raises(HDLCDecodeException) as exc:
@@ -60,21 +60,17 @@ def test_hdlc_handler_invalid_state():
     assert str(exc.value) == "Incomplete HDLC frame"
 
 
-def test_hdlc_handler_invalid_fcs(capsys):
-    handler = HDLCHandler(verbose=True)
+def test_hdlc_handler_invalid_fcs():
+    handler = HDLCHandler()
     for byte in b"~test\x42\x42~":
         handler.handle_byte(int(byte).to_bytes(1, "little"))
     payload = handler.payload
-    capture = capsys.readouterr()
     assert payload == bytearray()
-    assert capture.out.strip() == "Invalid FCS"
 
 
-def test_hdlc_handler_payload_too_short(capsys):
-    handler = HDLCHandler(verbose=True)
+def test_hdlc_handler_payload_too_short():
+    handler = HDLCHandler()
     for byte in b"~a~":
         handler.handle_byte(int(byte).to_bytes(1, "little"))
     payload = handler.payload
-    capture = capsys.readouterr()
     assert payload == bytearray()
-    assert capture.out.strip() == "Invalid payload"

--- a/dotbot/tests/test_main.py
+++ b/dotbot/tests/test_main.py
@@ -29,6 +29,9 @@ Options:
   -T, --table                     Display table in terminal
   -v, --verbose                   Run in verbose mode (all payloads received are
                                   printed in terminal)
+  --log-level [debug|info|warning|error]
+                                  Logging level. Defaults to info
+  --log-output PATH               Filename where logs are redirected
   --help                          Show this message and exit.
 """
 

--- a/dotbot/tests/test_server.py
+++ b/dotbot/tests/test_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 from unittest.mock import MagicMock, patch
 
@@ -631,10 +632,10 @@ async def test_ws_client():
 
 @pytest.mark.asyncio
 @patch("uvicorn.Server.serve")
-async def test_web(serve, capsys):
+async def test_web(serve, caplog):
+    caplog.set_level(logging.DEBUG, logger="pydotbot")
     with pytest.raises(SystemExit):
         await web(None)
     serve.side_effect = asyncio.exceptions.CancelledError()
     await web(None)
-    out, _ = capsys.readouterr()
-    assert "Web server cancelled" in out
+    assert "Web server cancelled" in caplog.text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "pyserial       == 3.5",
     "pynput         == 1.7.6",
     "rich           == 12.6.0",
+    "structlog      == 22.3.0",
     "uvicorn        == 0.18.3",
     "websockets     == 10.4",
 ]


### PR DESCRIPTION
This adds a way to store runtime logs in a file and in a structured way. The logs are stored using logfmt format so it's easy to post process them to analyze the behavior of the system. For example, it can be used to analyze the delays between consecutive computations of LH2 positions, even if there are multiple dotbots connected.