### PR TITLE
pyproject.toml: bump pygame dependency to 2.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "haversine      == 2.7.0",
     "numpy          == 1.23.4",
     "opencv-python  == 4.6.0.66",
-    "pygame         == 2.1.2",
+    "pygame         == 2.4.0",
     "pyserial       == 3.5",
     "pynput         == 1.7.6",
     "rich           == 12.6.0",


### PR DESCRIPTION
This version is required with python 3.11