### PR TITLE
Demo with `lake-authz`

### DIFF
--- a/dotbot/controller.py
+++ b/dotbot/controller.py
@@ -259,7 +259,7 @@ class Controller:
             loc_w = "http://localhost:8000/.well-known/lake-authz/voucher-request"
         else:
             self.logger.error("Unknown enrollment server", loc_w=loc_w)
-            self.pending_dobots.remove(dotbot.address)
+            self.pending_dotbots.pop(dotbot.address)
             return
         response = requests.post(loc_w, data=voucher_request)
         if response.status_code == 200:
@@ -283,7 +283,7 @@ class Controller:
             )
         else:
             self.logger.error("Error requesting voucher", status_code=response.status_code)
-            self.pending_dobots.remove(dotbot.address)
+            self.pending_dotbots.pop(dotbot.address)
 
     def handle_received_payload(
         self, payload: ProtocolPayload
@@ -314,7 +314,6 @@ class Controller:
         if source not in self.dotbots and source not in self.pending_dotbots and payload.payload_type == PayloadType.EDHOC_MESSAGE: # or PayloadType.ADVERTISEMENT:
             logger.info("New potential dotbot")
             try:
-                logger.debug("Will process EDHOC message", values=payload.values)
                 message_1 = payload.values.value
                 logger.debug("Will process EDHOC message", message_1=message_1)
                 ead_1 = self.edhoc_responder.process_message_1(message_1)
@@ -332,7 +331,8 @@ class Controller:
             logger.info("Message from pending dotbot")
             # verify message 3
             try:
-                message_3 = payload.values[0]
+                message_3 = payload.values.value
+                logger.debug("Will process EDHOC message", message_3=message_3)
                 id_cred_i, _ead_3 = self.edhoc_responder.parse_message_3(message_3)
                 valid_cred_i = lakers.credential_check_or_fetch(id_cred_i, CRED_I)
                 _r_prk_out = self.edhoc_responder.verify_message_3(valid_cred_i)
@@ -340,7 +340,7 @@ class Controller:
                 logger.error("Error processing message 3", error=e)
                 return
             logger.info("New dotbot")
-            self.pending_dotbots.remove(source)
+            self.pending_dotbots.pop(source)
             notification_cmd = DotBotNotificationCommand.RELOAD
         elif source in self.dotbots:
             dotbot.mode = self.dotbots[source].mode

--- a/dotbot/controller.py
+++ b/dotbot/controller.py
@@ -5,6 +5,8 @@ import json
 import math
 import time
 import webbrowser
+import requests
+import lakers
 from binascii import hexlify
 from dataclasses import dataclass
 from typing import Dict, List, Optional
@@ -39,6 +41,7 @@ from dotbot.protocol import (
     ProtocolHeader,
     ProtocolPayload,
     ProtocolPayloadParserException,
+    EdhocMessage,
 )
 from dotbot.serial_interface import SerialInterface, SerialInterfaceException
 from dotbot.server import api
@@ -57,6 +60,9 @@ DEAD_DELAY = 60  # seconds
 LH2_POSITION_DISTANCE_THRESHOLD = 0.01
 GPS_POSITION_DISTANCE_THRESHOLD = 5  # meters
 
+CRED_I = bytes.fromhex("A2027734322D35302D33312D46462D45462D33372D33322D333908A101A5010202412B2001215820AC75E9ECE3E50BFC8ED60399889522405C47BF16DF96660A41298CB4307F7EB62258206E5DE611388A4B8A8211334AC7D37ECB52A387D257E6DB3C2A93DF21FF3AFFC8")
+V = bytes.fromhex("72cc4761dbd4c78f758931aa589d348d1ef874a7e303ede2f140dcf3e6aa4aac")
+CRED_V = bytes.fromhex("a2026b6578616d706c652e65647508a101a501020241322001215820bbc34960526ea4d32e940cad2a234148ddc21791a12afbcbac93622046dd44f02258204519e257236b2a0ce2023f0931f1f386ca7afda64fcde0108c224c51eabf6072")
 
 class ControllerException(Exception):
     """Exception raised by Dotbot controllers."""
@@ -137,6 +143,9 @@ class Controller:
         if settings.use_mqtt is True:
             self.mqtt.init_app(api)
         self.logger = LOGGER.bind(context=__name__)
+        self.pending_dotbots: Dict[str, DotBotModel] = {}
+        self.edhoc_responder = lakers.EdhocResponder(V, CRED_V)
+        self.edhoc_ead_authenticator = lakers.AuthzAutenticator()
 
     async def _start_serial(self):
         """Starts the serial listener thread in a coroutine."""
@@ -243,6 +252,39 @@ class Controller:
                     return
                 self.handle_received_payload(payload)
 
+    async def request_voucher_for_dotbot(self, dotbot: DotBotModel, ead_1: bytes, message_1: bytes):
+        loc_w, voucher_request = self.edhoc_ead_authenticator.process_ead_1(ead_1, message_1)
+        # NOTE: overriding loc_w, so that we can run the flow using the existing test vectors
+        if loc_w == b"coap://enrollment.server":
+            loc_w = "http://localhost:8000/.well-known/lake-authz/voucher-request"
+        else:
+            self.logger.error("Unknown enrollment server", loc_w=loc_w)
+            self.pending_dobots.remove(dotbot.address)
+            return
+        response = requests.post(loc_w, data=voucher_request)
+        if response.status_code == 200:
+            self.logger.info("Got voucher", voucher=response.content)
+            ead_2 = self.edhoc_ead_authenticator.prepare_ead_2(response.content)
+            message_2 = self.edhoc_responder.prepare_message_2(lakers.CredentialTransfer.ByReference, None, ead_2)
+
+            header = ProtocolHeader(
+                destination=int(dotbot.address, 16),
+                source=int(self.settings.gw_address, 16),
+                swarm_id=int(self.settings.swarm_id, 16),
+                application=dotbot.application,
+                version=PROTOCOL_VERSION,
+            )
+            self.send_payload_to_pending(
+                ProtocolPayload(
+                    header,
+                    PayloadType.EDHOC_MESSAGE,
+                    EdhocMessage(value=message_2),
+                )
+            )
+        else:
+            self.logger.error("Error requesting voucher", status_code=response.status_code)
+            self.pending_dobots.remove(dotbot.address)
+
     def handle_received_payload(
         self, payload: ProtocolPayload
     ):  # pylint:disable=too-many-branches,too-many-statements
@@ -269,7 +311,38 @@ class Controller:
             last_seen=time.time(),
         )
         notification_cmd = DotBotNotificationCommand.NONE
-        if source in self.dotbots:
+        if source not in self.dotbots and source not in self.pending_dotbots and payload.payload_type == PayloadType.EDHOC_MESSAGE: # or PayloadType.ADVERTISEMENT:
+            logger.info("New potential dotbot")
+            try:
+                logger.debug("Will process EDHOC message", values=payload.values)
+                message_1 = payload.values.value
+                logger.debug("Will process EDHOC message", message_1=message_1)
+                ead_1 = self.edhoc_responder.process_message_1(message_1)
+            except Exception as e:
+                logger.error("Error processing message 1", error=e)
+                return
+            if ead_1 and ead_1.label() == 1:
+                self.pending_dotbots[dotbot.address] = dotbot
+                asyncio.create_task(self.request_voucher_for_dotbot(dotbot, ead_1, message_1))
+                return
+            else:
+                logger.error("EDHOC message 1 should contain a valid EAD_1")
+                return
+        elif source not in self.dotbots and source in self.pending_dotbots and payload.payload_type == PayloadType.EDHOC_MESSAGE:
+            logger.info("Message from pending dotbot")
+            # verify message 3
+            try:
+                message_3 = payload.values[0]
+                id_cred_i, _ead_3 = self.edhoc_responder.parse_message_3(message_3)
+                valid_cred_i = lakers.credential_check_or_fetch(id_cred_i, CRED_I)
+                _r_prk_out = self.edhoc_responder.verify_message_3(valid_cred_i)
+            except Exception as e:
+                logger.error("Error processing message 3", error=e)
+                return
+            logger.info("New dotbot")
+            self.pending_dotbots.remove(source)
+            notification_cmd = DotBotNotificationCommand.RELOAD
+        elif source in self.dotbots:
             dotbot.mode = self.dotbots[source].mode
             dotbot.status = self.dotbots[source].status
             dotbot.direction = self.dotbots[source].direction
@@ -280,6 +353,7 @@ class Controller:
             dotbot.waypoints_threshold = self.dotbots[source].waypoints_threshold
             dotbot.position_history = self.dotbots[source].position_history
         else:
+            # what do to here?
             # reload if a new dotbot comes in
             logger.info("New dotbot")
             notification_cmd = DotBotNotificationCommand.RELOAD
@@ -405,7 +479,26 @@ class Controller:
         payload.header.application = self.dotbots[destination].application
         if self.serial is not None:
             self.serial.write(hdlc_encode(payload.to_bytes()))
-            self.logger.debug(
+            self.logger.info(
+                "Payload sent",
+                application=payload.header.application.name,
+                destination=destination,
+                payload_type=payload.payload_type.name,
+            )
+
+    def send_payload_to_pending(self, payload: ProtocolPayload):
+        """Sends a command in an HDLC frame over serial."""
+        destination = hexlify(
+            int(payload.header.destination).to_bytes(8, "big")
+        ).decode()
+        if destination not in self.pending_dotbots:
+            return
+        # make sure the application in the payload matches the bot application
+        payload.header.application = self.pending_dotbots[destination].application
+        print("sending...")
+        if self.serial is not None:
+            self.serial.write(hdlc_encode(payload.to_bytes()))
+            self.logger.info(
                 "Payload sent",
                 application=payload.header.application.name,
                 destination=destination,
@@ -448,7 +541,7 @@ class Controller:
     async def web(self):
         """Starts the web server application."""
         logger = LOGGER.bind(context=__name__)
-        config = uvicorn.Config(api, port=8000, log_level="critical")
+        config = uvicorn.Config(api, port=10000, log_level="critical")
         server = uvicorn.Server(config)
 
         try:

--- a/dotbot/protocol.py
+++ b/dotbot/protocol.py
@@ -25,7 +25,8 @@ class PayloadType(Enum):
     LH2_WAYPOINTS = 8
     GPS_WAYPOINTS = 9
     SAILBOT_DATA = 10
-    INVALID_PAYLOAD = 11  # Increase each time a new payload type is added
+    EDHOC_MESSAGE = 11
+    INVALID_PAYLOAD = 12  # Increase each time a new payload type is added
 
 
 class ApplicationType(IntEnum):
@@ -304,6 +305,23 @@ class Advertisement(ProtocolData):
 
 
 @dataclass
+class EdhocMessage(ProtocolData):
+    """Dataclass that holds an EDHOC Message."""
+
+    value: bytes = b""
+
+    @property
+    def fields(self) -> List[ProtocolField]:
+        return [
+            ProtocolField(self.value, "value", len(self.value)),
+        ]
+
+    @staticmethod
+    def from_bytes(bytes_: bytes) -> ProtocolData:
+        return EdhocMessage(value=bytes_)
+
+
+@dataclass
 class ControlMode(ProtocolData):
     """Dataclass that holds a control mode message."""
 
@@ -375,9 +393,13 @@ class ProtocolPayload:
             )
         buffer += int(self.payload_type.value).to_bytes(length=1, byteorder=endian)
         for field in self.values.fields:
-            buffer += int(field.value).to_bytes(
-                length=field.length, byteorder=endian, signed=field.signed
-            )
+            try:
+                buffer += int(field.value).to_bytes(
+                    length=field.length, byteorder=endian, signed=field.signed
+                )
+            except ValueError:
+                # TODO: better way to do this? (encode values that already are 'bytes' and should just be sent as-is)
+                buffer += field.value
         return buffer
 
     @staticmethod
@@ -414,6 +436,8 @@ class ProtocolPayload:
             values = LH2Waypoints.from_bytes(None)
         elif payload_type == PayloadType.GPS_WAYPOINTS:
             values = GPSWaypoints.from_bytes(None)
+        elif payload_type == PayloadType.EDHOC_MESSAGE:
+            values = EdhocMessage.from_bytes(bytes_[25:])
         else:
             raise ProtocolPayloadParserException(
                 f"Unsupported payload type '{payload_type.value}'"

--- a/utils/falso_edhoc_initiator.py
+++ b/utils/falso_edhoc_initiator.py
@@ -1,4 +1,17 @@
-import serial
+"""
+For this script to work, you need to have a virtual serial port pair created. You can do this with socat:
+
+```
+socat -d -d pty,raw,echo=0 pty,raw,echo=0
+```
+
+It will output the paths to the created virtual serial ports, for example /dev/pts/74 and /dev/pts/75.
+
+Then, start the dotbot-controller with -p /dev/pts/74, and run this script with /dev/pts/75 as the serial port.
+"""
+
+import serial, sys, lakers
+import time
 
 from dotbot.hdlc import hdlc_decode, hdlc_encode
 from dotbot import GATEWAY_ADDRESS_DEFAULT, SWARM_ID_DEFAULT
@@ -47,18 +60,62 @@ class FalsoBot:
     def parse_serial_input(self, frame):
         payload = ProtocolPayload.from_bytes(hdlc_decode(frame))
 
-        if self.address == hex(payload.header.destination)[2:]:
-            print("received payload:", payload.payload)
+        if self.address == hex(payload.header.destination)[2:] and payload.payload_type == PayloadType.EDHOC_MESSAGE:
+            print("received payload:", payload.values.value)
+            return payload.values.value
+        else:
+            raise Exception("message not for me or not an edhoc message")
 
 fb = FalsoBot("1234567890123456")
 
-MESSAGE_1_WITH_EAD = bytes.fromhex("0382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b6370158287818636f61703a2f2f656e726f6c6c6d656e742e7365727665724dda9784962883c96ed01ff122c3")
 
-with serial.Serial("/dev/pts/75", timeout=1) as ser:
-    print("sending msg1:", fb.edhoc_message(MESSAGE_1_WITH_EAD))
-    ser.write(fb.edhoc_message(MESSAGE_1_WITH_EAD))
+# values from traces-zeroconf.ipynb
+ID_U = bytes.fromhex("a104412b")
+G_W = bytes.fromhex("FFA4F102134029B3B156890B88C9D9619501196574174DCB68A07DB0588E4D41")
+LOC_W = bytes.fromhex("636f61703a2f2f656e726f6c6c6d656e742e736572766572")
+W = bytes.fromhex("4E5E15AB35008C15B89E91F9F329164D4AACD53D9923672CE0019F9ACD98573F")
+KID_I = 0x2b
+CRED_I = bytes.fromhex("A2027734322D35302D33312D46462D45462D33372D33322D333908A101A5010202412B2001215820AC75E9ECE3E50BFC8ED60399889522405C47BF16DF96660A41298CB4307F7EB62258206E5DE611388A4B8A8211334AC7D37ECB52A387D257E6DB3C2A93DF21FF3AFFC8")
+I = bytes.fromhex("fb13adeb6518cee5f88417660841142e830a81fe334380a953406a1305e8706b")
+CRED_V = bytes.fromhex("a2026b6578616d706c652e65647508a101a501020241322001215820bbc34960526ea4d32e940cad2a234148ddc21791a12afbcbac93622046dd44f02258204519e257236b2a0ce2023f0931f1f386ca7afda64fcde0108c224c51eabf6072")
+V = bytes.fromhex("72cc4761dbd4c78f758931aa589d348d1ef874a7e303ede2f140dcf3e6aa4aac")
+EAD_1_VALUE = bytes.fromhex("58287818636f61703a2f2f656e726f6c6c6d656e742e7365727665724dda9784962883c96ed01ff122c3")
+MESSAGE_1_WITH_EAD = bytes.fromhex("0382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b6370158287818636f61703a2f2f656e726f6c6c6d656e742e7365727665724dda9784962883c96ed01ff122c3")
+VOUCHER_RESPONSE = bytes.fromhex("8258520382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b6370158287818636f61703a2f2f656e726f6c6c6d656e742e7365727665724dda9784962883c96ed01ff122c34948c783671337f75bd5")
+EAD_2_VALUE = bytes.fromhex("48c783671337f75bd5")
+
+initiator = lakers.EdhocInitiator()
+device = lakers.AuthzDevice(
+    ID_U,
+    G_W,
+    LOC_W,
+)
+
+ead_1 = device.prepare_ead_1(
+    initiator.compute_ephemeral_secret(device.get_g_w()),
+    initiator.selected_cipher_suite(),
+)
+message_1 = initiator.prepare_message_1(c_i=None, ead_1=ead_1)
+device.set_h_message_1(initiator.get_h_message_1())
+
+
+with serial.Serial(sys.argv[1], timeout=1) as ser:
+    print("sending msg1:", fb.edhoc_message(message_1))
+    ser.write(fb.edhoc_message(message_1))
     while True:
-        msg2 = ser.read(256)
-        if len(msg2) > 0:
+        message_2 = ser.read(256)
+        if len(message_2) > 0:
+            message_2 = fb.parse_serial_input(message_2)
             break
-    #
+    c_r, id_cred_r, ead_2 = initiator.parse_message_2(message_2)
+    valid_cred_r = lakers.credential_check_or_fetch(id_cred_r, CRED_V)
+    assert device.process_ead_2(ead_2, CRED_V)
+    print(f"Authz voucher is valid!")
+    initiator.verify_message_2(I, CRED_I, valid_cred_r)
+    print(f"Message 2 is valid!")
+    message_3, i_prk_out = initiator.prepare_message_3(lakers.CredentialTransfer.ByReference, None)
+    ser.write(fb.edhoc_message(message_3))
+    time.sleep(1)
+    ser.write(fb.advertise())
+    while True:
+        pass

--- a/utils/falso_edhoc_initiator.py
+++ b/utils/falso_edhoc_initiator.py
@@ -1,0 +1,64 @@
+import serial
+
+from dotbot.hdlc import hdlc_decode, hdlc_encode
+from dotbot import GATEWAY_ADDRESS_DEFAULT, SWARM_ID_DEFAULT
+from dotbot.hdlc import hdlc_decode, hdlc_encode
+from dotbot.logger import LOGGER
+from dotbot.protocol import (
+    PROTOCOL_VERSION,
+    Advertisement,
+    EdhocMessage,
+    ApplicationType,
+    PayloadType,
+    ProtocolHeader,
+    ProtocolPayload,
+)
+
+class FalsoBot:
+    def __init__(self, address):
+        self.address = address
+
+    @property
+    def header(self):
+        return ProtocolHeader(
+            destination=int(GATEWAY_ADDRESS_DEFAULT, 16),
+            source=int(self.address, 16),
+            swarm_id=int(SWARM_ID_DEFAULT, 16),
+            application=ApplicationType.DotBot,
+            version=PROTOCOL_VERSION,
+        )
+
+    def advertise(self):
+        payload = ProtocolPayload(
+            self.header,
+            PayloadType.ADVERTISEMENT,
+            Advertisement(),
+        )
+        return hdlc_encode(payload.to_bytes())
+
+    def edhoc_message(self, message):
+        payload = ProtocolPayload(
+            self.header,
+            PayloadType.EDHOC_MESSAGE,
+            EdhocMessage(value=message),
+        )
+        return hdlc_encode(payload.to_bytes())
+
+    def parse_serial_input(self, frame):
+        payload = ProtocolPayload.from_bytes(hdlc_decode(frame))
+
+        if self.address == hex(payload.header.destination)[2:]:
+            print("received payload:", payload.payload)
+
+fb = FalsoBot("1234567890123456")
+
+MESSAGE_1_WITH_EAD = bytes.fromhex("0382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b6370158287818636f61703a2f2f656e726f6c6c6d656e742e7365727665724dda9784962883c96ed01ff122c3")
+
+with serial.Serial("/dev/pts/75", timeout=1) as ser:
+    print("sending msg1:", fb.edhoc_message(MESSAGE_1_WITH_EAD))
+    ser.write(fb.edhoc_message(MESSAGE_1_WITH_EAD))
+    while True:
+        msg2 = ser.read(256)
+        if len(msg2) > 0:
+            break
+    #


### PR DESCRIPTION
This PR aims at integrating zero-touch secure network join for DotBots. The goal is to work as follows:
1. DotBots will perform an EDHOC handshake with PyDotBot. The messages will contain additional authorization information in the EAD field, which will be handled according to the [`lake-authz`](https://lake-wg.github.io/authz/draft-ietf-lake-authz.html) draft, implemented in the [`lakers-python`](https://pypi.org/project/lakers-python/) package.
2. PyDotBot will communicate with a [`dotbot-manager`](https://github.com/DotBots/dotbot-manager) to obtain the authorization information and allow/deny the join of new DotBots.

Changes so far include:
- a new type of message to the protocol: `EDHOC_MESSAGE`.
- some logic in the controller to handle new and pending dotbots
- an integration test script that permits the emulation of a DotBot device from Python, via virtual serial interfaces