### PR TITLE
#130 Windows: fix lh2 functions not found on manual windows install

### DIFF
--- a/dotbot/lib/.gitignore
+++ b/dotbot/lib/.gitignore
@@ -2,3 +2,4 @@ _build/
 *.so
 *.dll
 *.dylib
+*.lib

--- a/dotbot/lib/CMakeLists.txt
+++ b/dotbot/lib/CMakeLists.txt
@@ -5,6 +5,7 @@ project(lh2)
 
 if (MSVC)
     set(CMAKE_BUILD_TYPE Release)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 else()
     add_compile_options(-std=c11 -Ofast -Wall -Werror)
 endif()


### PR DESCRIPTION
@aabadie fixed it with a change to the CMakefile