### PR TITLE
Improve sim scalability

### DIFF
--- a/dotbot/frontend/src/RestApp.js
+++ b/dotbot/frontend/src/RestApp.js
@@ -44,7 +44,7 @@ const RestApp = () => {
     log.info(`Publishing message: ${message} to topic: ${topic}`);
   }, []);
 
-const onWsOpen = () => {
+  const onWsOpen = () => {
     log.info('websocket opened');
     fetchDotBots();
   };
@@ -104,6 +104,7 @@ const onWsOpen = () => {
     onClose: () => log.warn("websocket closed"),
     onMessage: (event) => onWsMessage(event),
     shouldReconnect: (event) => true,
+    filter: () => false,
   });
 
   useEffect(() => {


### PR DESCRIPTION
Found the main problem on simulator frontend.

The problem was related to the [filter callback](https://github.com/robtaussig/react-use-websocket?tab=readme-ov-file#filter-callback). By default, the hook updates its internal state on every incoming message, which causes the component to re-render. Now its set to false to never update the FE, only when we want (with `onWsMessage`)

The simulator before worked fine with ~30 dotbots on my machine, but now seems fine with ~200. (only tested with changing colors).

I found a couple more improvements, will test and send improvements in small PRs.

[recording (7).webm](https://github.com/user-attachments/assets/15696659-32b0-4325-a1f9-aba77c8c3eef)


