### PR TITLE
dotbot/frontend: fix dotbot direction arrow ratio on map

### DIFF
--- a/dotbot/frontend/src/DotBotsMap.js
+++ b/dotbot/frontend/src/DotBotsMap.js
@@ -149,7 +149,9 @@ const DotBotsMapPoint = React.memo((props) => {
         onMouseLeave={onMouseLeave} >
       <title>{`${props.dotbot.address}@${posX}x${posY}`}</title>
     </circle>
-    {(props.dotbot.direction) && <polygon points={`${posX - radius + 10},${posY + radius + directionShift} ${posX + radius - 10},${posY + radius + directionShift} ${posX},${posY + radius + directionSize + directionShift}`} fill={rgbColor} opacity={opacity} />}
+    {(props.dotbot.direction) &&
+      <polygon points={`${posX - radius + 10 * props.mapSize / props.areaSize.width},${posY + radius + directionShift} ${posX + radius - 10 * props.mapSize / props.areaSize.width},${posY + radius + directionShift} ${posX},${posY + radius + directionSize + directionShift}`} fill={rgbColor} opacity={opacity} />
+    }
     </g>
     </>
   )


### PR DESCRIPTION
The arrow ratio is now kept regardless of the map size. Before the map size was ignored.

Current main:

- 2500x2500 map size
<img width="347" height="318" alt="image" src="https://github.com/user-attachments/assets/99ba96be-f96c-4822-bb04-7c6dc40fff9d" />

- 5000x2500 map size
<img width="752" height="355" alt="image" src="https://github.com/user-attachments/assets/c0a9cc9c-40ec-40d2-b2b2-fe07f4e5415a" />

This PR:

- 2500x2500 map size
<img width="356" height="331" alt="image" src="https://github.com/user-attachments/assets/157a5b9b-e9cc-4ac0-8876-51ead80f7794" />

- 5000x2500 map size
<img width="700" height="326" alt="image" src="https://github.com/user-attachments/assets/a87657a4-5ef8-4bdc-a0f4-40d5685d10d7" />
