### PR TITLE
frontend: improve websocket reconnect strategy

### DIFF
--- a/dotbot/frontend/src/RestApp.tsx
+++ b/dotbot/frontend/src/RestApp.tsx
@@ -87,6 +87,7 @@ const RestApp: React.FC = () => {
     onClose: () => log.warn("websocket closed"),
     onMessage: (event) => onWsMessage(event),
     shouldReconnect: () => true,
+    reconnectInterval: (attempt) => Math.min(500 * 2 ** attempt, 10000),
     filter: () => false,
   });
 


### PR DESCRIPTION
Sometimes the UI is stalled blank for several seconds before websocket reconnects and that is annoying. The problem is gone with this PR.