### PR TITLE
dotvot/controller_app: add --simulator-init-state option

### DIFF
--- a/config_sample.toml
+++ b/config_sample.toml
@@ -24,4 +24,4 @@ log_level = "info"
 log_output = "pydotbot.log"
 
 # --- Simulator ---
-simulator_init_state_path = "simulator_init_state.toml"
+simulator_init_state = "simulator_init_state.toml"

--- a/dotbot/__init__.py
+++ b/dotbot/__init__.py
@@ -16,7 +16,7 @@ CONTROLLER_ADAPTER_DEFAULT = "serial"
 MQTT_HOST_DEFAULT = "localhost"
 MQTT_PORT_DEFAULT = 1883
 MAP_SIZE_DEFAULT = "2000x2000"  # in mm unit
-SIMULATOR_INIT_STATE_PATH_DEFAULT = "simulator_init_state.toml"
+SIMULATOR_INIT_STATE_DEFAULT = "simulator_init_state.toml"
 
 
 def pydotbot_version() -> str:

--- a/dotbot/adapter.py
+++ b/dotbot/adapter.py
@@ -19,7 +19,7 @@ from marilib.marilib_cloud import MarilibCloud
 from marilib.marilib_edge import MarilibEdge
 from marilib.model import EdgeEvent, MariNode
 
-from dotbot import SIMULATOR_INIT_STATE_PATH_DEFAULT
+from dotbot import SIMULATOR_INIT_STATE_DEFAULT
 from dotbot.dotbot_simulator import DotBotSimulatorCommunicationInterface
 from dotbot.logger import LOGGER
 from dotbot.sailbot_simulator import SailBotSimulatorCommunicationInterface
@@ -248,13 +248,13 @@ class DotBotSimulatorAdapter(SimulatorAdapterBase):
 
     def __init__(
         self,
-        simulator_init_state_path: str = SIMULATOR_INIT_STATE_PATH_DEFAULT,
+        simulator_init_state: str = SIMULATOR_INIT_STATE_DEFAULT,
     ):
-        self.simulator_init_state_path = simulator_init_state_path
+        self.simulator_init_state = simulator_init_state
 
     def create_simulator(self, on_frame_received: callable):
         return DotBotSimulatorCommunicationInterface(
-            on_frame_received, self.simulator_init_state_path
+            on_frame_received, self.simulator_init_state
         )
 
 

--- a/dotbot/controller.py
+++ b/dotbot/controller.py
@@ -38,7 +38,7 @@ from dotbot import (
     NETWORK_ID_DEFAULT,
     SERIAL_BAUDRATE_DEFAULT,
     SERIAL_PORT_DEFAULT,
-    SIMULATOR_INIT_STATE_PATH_DEFAULT,
+    SIMULATOR_INIT_STATE_DEFAULT,
 )
 from dotbot.adapter import (
     DotBotSimulatorAdapter,
@@ -132,7 +132,7 @@ class ControllerSettings:
     log_level: str = "info"
     log_output: str = os.path.join(os.getcwd(), "pydotbot.log")
     csv_data_output: Optional[str] = None
-    simulator_init_state_path: str = SIMULATOR_INIT_STATE_PATH_DEFAULT
+    simulator_init_state: str = SIMULATOR_INIT_STATE_DEFAULT
 
 
 def lh2_distance(last: DotBotLH2Position, new: DotBotLH2Position) -> float:
@@ -683,7 +683,7 @@ class Controller:
             )
         elif self.settings.adapter == "dotbot-simulator":
             self.adapter = DotBotSimulatorAdapter(
-                self.settings.simulator_init_state_path,
+                self.settings.simulator_init_state,
             )
         elif self.settings.adapter == "sailbot-simulator":
             self.adapter = SailBotSimulatorAdapter()

--- a/dotbot/controller_app.py
+++ b/dotbot/controller_app.py
@@ -24,6 +24,7 @@ from dotbot import (
     NETWORK_ID_DEFAULT,
     SERIAL_BAUDRATE_DEFAULT,
     SERIAL_PORT_DEFAULT,
+    SIMULATOR_INIT_STATE_DEFAULT,
     pydotbot_version,
 )
 from dotbot.controller import Controller, ControllerSettings
@@ -136,6 +137,11 @@ from dotbot.logger import setup_logging
         f"with the --map-size option (default: {MAP_SIZE_DEFAULT})."
     ),
 )
+@click.option(
+    "--simulator-init-state",
+    type=click.Path(dir_okay=False),
+    help=f"Path to the simulator initial state .toml file. Defaults to '{SIMULATOR_INIT_STATE_DEFAULT}'.",
+)
 def main(
     adapter,
     port,
@@ -148,6 +154,7 @@ def main(
     controller_http_port,
     map_size,
     background_map,
+    simulator_init_state,
     webbrowser,
     verbose,
     log_level,
@@ -172,6 +179,7 @@ def main(
         "controller_http_port": controller_http_port,
         "map_size": map_size,
         "background_map": background_map,
+        "simulator_init_state": simulator_init_state,
         "webbrowser": webbrowser,
         "verbose": verbose,
         "log_level": log_level,

--- a/dotbot/dotbot_simulator.py
+++ b/dotbot/dotbot_simulator.py
@@ -741,12 +741,12 @@ class MariNetworkSimulator:
 class DotBotSimulatorCommunicationInterface:
     """Bidirectional serial interface to control simulated robots"""
 
-    def __init__(self, on_frame_received: Callable, simulator_init_state_path: str):
+    def __init__(self, on_frame_received: Callable, simulator_init_state: str):
         self.queue = queue.Queue()
         self.on_frame_received = on_frame_received
         self._stp_event = threading.Event()
         self.main_thread = threading.Thread(target=self.run, daemon=True)
-        init_state = InitStateToml(**toml.load(simulator_init_state_path))
+        init_state = InitStateToml(**toml.load(simulator_init_state))
         self._network = init_state.network
         self.dotbots = [
             DotBotSimulator(

--- a/dotbot/examples/README.md
+++ b/dotbot/examples/README.md
@@ -17,11 +17,11 @@ We also provide a stop.py helper script to halt the simulator (without needing t
 ## Common usage pattern (default: simulator)
 
 1. Pick a scenario and read its local `README.md`.
-2. Set `simulator_init_state_path` in `config_sample.toml` as described by that scenario.
-3. Start the controller in simulator mode:
+2. Start the controller in simulator mode, passing the scenario's init state:
 
 ```bash
-python -m dotbot.controller_app --config-path config_sample.toml -a dotbot-simulator
+dotbot-controller -a dotbot-simulator \
+    --simulator-init-state <path/to/init_state.toml>
 ```
 
-4. Run the selected example using its documented command.
+3. Run the selected example using its documented command.

--- a/dotbot/examples/charging_station/README.md
+++ b/dotbot/examples/charging_station/README.md
@@ -7,21 +7,14 @@ The simulator setup below is the default path for reproducibility.
 
 ## How to run (default: simulator)
 
-### 1. Specify the initial state
-
-Set `simulator_init_state_path` in `config_sample.toml` to:
-
-```toml
-simulator_init_state_path = "dotbot/examples/charging_station/charging_station_init_state.toml"
-```
-
-### 2. Start the controller in simulator mode
+### 1. Start the controller in simulator mode
 
 ```bash
-python -m dotbot.controller_app --config-path config_sample.toml -a dotbot-simulator
+dotbot-controller -a dotbot-simulator \
+    --simulator-init-state dotbot/examples/charging_station/charging_station_init_state.toml
 ```
 
-### 3. Run the charging-station scenario
+### 2. Run the charging-station scenario
 
 From the `PyDotBot/` root in a new terminal:
 

--- a/dotbot/examples/minimum_naming_game/README.md
+++ b/dotbot/examples/minimum_naming_game/README.md
@@ -22,31 +22,25 @@ pip install pyyaml scipy
 
 ## How to run
 
-### Specify the initial state
+### 1. Start the controller in simulator mode
 
-Specify the initial state of the DotBots by replacing the file path for ```simulator_init_state_path``` in [config_sample.toml](config_sample.toml).
-
-**Static setup** (without motion) using init_state.toml:
-
-```toml
-simulator_init_state_path = "dotbot/examples/minimum_naming_game/init_state.toml"
-```
-
-**Dynamic setup** (with motion) using init_state_with_motion.toml:
-
-```toml
-simulator_init_state_path = "dotbot/examples/minimum_naming_game/init_state_with_motion.toml"
-```
-
-### Start the controller in simulator mode
+**Static setup** (without motion):
 
 ```bash
-python -m dotbot.controller_app --config-path config_sample.toml -a dotbot-simulator
+dotbot-controller -a dotbot-simulator \
+    --simulator-init-state dotbot/examples/minimum_naming_game/init_state.toml
 ```
 
-### Run the minimum naming game scenario
+**Dynamic setup** (with motion):
 
-Open a new terminal and run the minimum naming game scenario in the top-level directory ```PyDotBot/```.
+```bash
+dotbot-controller -a dotbot-simulator \
+    --simulator-init-state dotbot/examples/minimum_naming_game/init_state_with_motion.toml
+```
+
+### 2. Run the minimum naming game scenario
+
+From the `PyDotBot/` root in a new terminal:
 
 **Static setup** (without motion):
 
@@ -54,7 +48,7 @@ Open a new terminal and run the minimum naming game scenario in the top-level di
 python -m dotbot.examples.minimum_naming_game.minimum_naming_game
 ```
 
-**Dynamic setup** (with motion) :
+**Dynamic setup** (with motion):
 
 ```bash
 python -m dotbot.examples.minimum_naming_game.minimum_naming_game_with_motion

--- a/dotbot/examples/work_and_charge/README.md
+++ b/dotbot/examples/work_and_charge/README.md
@@ -16,23 +16,16 @@ pip install pyyaml
 
 ## How to run
 
-### Specify the initial state
-
-Specify the initial state of the DotBots by replacing the file path for ```simulator_init_state_path``` in [config_sample.toml](https://github.com/DotBots/PyDotBot/blob/main/config_sample.toml).
-
-```toml
-simulator_init_state_path = "dotbot/examples/work_and_charge/init_state.toml"
-```
-
-### Start the controller in simulator mode
+### 1. Start the controller in simulator mode
 
 ```bash
-python -m dotbot.controller_app --config-path config_sample.toml -a dotbot-simulator
+dotbot-controller -a dotbot-simulator \
+    --simulator-init-state dotbot/examples/work_and_charge/init_state.toml
 ```
 
-### Run the work-and-charge scenario
+### 2. Run the work-and-charge scenario
 
-Open a new terminal and run the work-and-charge scenario in the top-level directory ```PyDotBot/```.
+From the `PyDotBot/` root in a new terminal:
 
 ```bash
 python -m dotbot.examples.work_and_charge.work_and_charge

--- a/dotbot/tests/test_controller_app.py
+++ b/dotbot/tests/test_controller_app.py
@@ -51,6 +51,8 @@ Options:
                                   height proportional to the real map size. The
                                   map size should be set with the --map-size
                                   option (default: 2000x2000).
+  --simulator-init-state FILE     Path to the simulator initial state .toml
+                                  file. Defaults to 'simulator_init_state.toml'.
   --help                          Show this message and exit.
 """
 


### PR DESCRIPTION
This simplify the usage of applications where there's no need anymore to edit the config-sample.toml file