### PR TITLE
dotbot/frontend: use native Websocket and adapt tests

### DIFF
--- a/dotbot/frontend/src/RestApp.test.tsx
+++ b/dotbot/frontend/src/RestApp.test.tsx
@@ -3,17 +3,24 @@ import { render, screen, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
-// Capture WebSocket callbacks for manual invocation in tests
-let capturedOnOpen: () => void = () => {};
-let capturedOnMessage: (event: MessageEvent) => void = () => {};
+// Mock native WebSocket so tests never hit the network
+type MockWs = {
+  onopen: (() => void) | null;
+  onclose: (() => void) | null;
+  onmessage: ((event: MessageEvent) => void) | null;
+  readyState: number;
+  close: ReturnType<typeof vi.fn>;
+};
 
-vi.mock('react-use-websocket', () => ({
-  default: (_url: string, opts: { onOpen?: () => void; onMessage?: (event: MessageEvent) => void }) => {
-    if (opts.onOpen) capturedOnOpen = opts.onOpen;
-    if (opts.onMessage) capturedOnMessage = opts.onMessage;
-    return {};
+let capturedWs: MockWs | null = null;
+
+const MockWebSocket = Object.assign(
+  function MockWebSocket() {
+    capturedWs = { onopen: null, onclose: null, onmessage: null, readyState: 0, close: vi.fn() };
+    return capturedWs;
   },
-}));
+  { CONNECTING: 0, OPEN: 1, CLOSING: 2, CLOSED: 3 },
+);
 
 vi.mock('./utils/rest', () => ({
   apiFetchDotbots: vi.fn(),
@@ -83,6 +90,8 @@ const dotbot = {
 };
 
 beforeEach(() => {
+  capturedWs = null;
+  vi.stubGlobal('WebSocket', MockWebSocket);
   vi.clearAllMocks();
   capturedPublishCommand = async () => {};
   mockedFetchMapSize.mockResolvedValue(areaSize);
@@ -95,6 +104,10 @@ beforeEach(() => {
   mockedHandleDotBotUpdate.mockImplementation((prev) => prev);
 });
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 // ─── Mount behaviour ────────────────────────────────────────────────────────
 
 test('RestApp fetches areaSize and backgroundMap on mount', async () => {
@@ -103,10 +116,9 @@ test('RestApp fetches areaSize and backgroundMap on mount', async () => {
   await waitFor(() => expect(mockedFetchBackgroundMap).toHaveBeenCalledOnce());
 });
 
-test('RestApp does not fetch dotbots on mount (dotbots starts as empty array)', async () => {
+test('RestApp fetches dotbots on mount as connection health check', async () => {
   render(<RestApp />);
-  await waitFor(() => expect(mockedFetchMapSize).toHaveBeenCalledOnce());
-  expect(mockedFetchDotbots).not.toHaveBeenCalled();
+  await waitFor(() => expect(mockedFetchDotbots).toHaveBeenCalled());
 });
 
 test('RestApp renders nothing until areaSize resolves', () => {
@@ -124,58 +136,49 @@ test('RestApp renders DotBots after areaSize resolves', async () => {
 
 test('RestApp fetches dotbots when WebSocket opens', async () => {
   render(<RestApp />);
-  await waitFor(() => expect(screen.getByTestId('dotbots')).toBeInTheDocument());
-  await act(async () => {
-    capturedOnOpen();
-  });
+  await waitFor(() => expect(capturedWs).not.toBeNull());
+  vi.clearAllMocks();
+  await act(async () => { capturedWs?.onopen?.(); });
   await waitFor(() => expect(mockedFetchDotbots).toHaveBeenCalledOnce());
 });
 
 test('RestApp WS Reload message triggers fetchDotBots', async () => {
   render(<RestApp />);
-  await waitFor(() => expect(screen.getByTestId('dotbots')).toBeInTheDocument());
+  await waitFor(() => expect(capturedWs).not.toBeNull());
+  vi.clearAllMocks();
   await act(async () => {
-    capturedOnMessage(
+    capturedWs?.onmessage?.(
       new MessageEvent('message', {
         data: JSON.stringify({ cmd: NotificationType.Reload }),
       }),
     );
   });
-  await waitFor(() => expect(mockedFetchDotbots).toHaveBeenCalled());
+  await waitFor(() => expect(mockedFetchDotbots).toHaveBeenCalledOnce());
 });
 
 test('RestApp WS NewDotBot message appends a dotbot', async () => {
   render(<RestApp />);
-  await waitFor(() => expect(screen.getByTestId('dotbots')).toBeInTheDocument());
-  expect(screen.getByTestId('dotbots')).toHaveTextContent('0');
+  // After health check, dotbots is populated with [dotbot] → count is 1
+  await waitFor(() => expect(screen.getByTestId('dotbots')).toHaveTextContent('1'));
 
   await act(async () => {
-    capturedOnMessage(
+    capturedWs?.onmessage?.(
       new MessageEvent('message', {
         data: JSON.stringify({ cmd: NotificationType.NewDotBot, data: dotbot }),
       }),
     );
   });
-  await waitFor(() => expect(screen.getByTestId('dotbots')).toHaveTextContent('1'));
+  await waitFor(() => expect(screen.getByTestId('dotbots')).toHaveTextContent('2'));
 });
 
 test('RestApp WS Update message calls handleDotBotUpdate when dotbots are present', async () => {
   render(<RestApp />);
-  await waitFor(() => expect(screen.getByTestId('dotbots')).toBeInTheDocument());
-
-  // Populate dotbots via NewDotBot first
-  await act(async () => {
-    capturedOnMessage(
-      new MessageEvent('message', {
-        data: JSON.stringify({ cmd: NotificationType.NewDotBot, data: dotbot }),
-      }),
-    );
-  });
-  await waitFor(() => expect(screen.getByTestId('dotbots')).toHaveTextContent('1'));
+  // After health check dotbots is non-empty; send Update directly
+  await waitFor(() => expect(capturedWs).not.toBeNull());
 
   const updateMsg = { cmd: NotificationType.Update, data: { address: 'aabbccddeeff', status: 2 } };
   await act(async () => {
-    capturedOnMessage(
+    capturedWs?.onmessage?.(
       new MessageEvent('message', { data: JSON.stringify(updateMsg) }),
     );
   });

--- a/dotbot/frontend/src/RestApp.tsx
+++ b/dotbot/frontend/src/RestApp.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { NotificationType } from "./utils/constants";
 import { handleDotBotUpdate } from "./utils/helpers";
 
-import useWebSocket from 'react-use-websocket';
 import {
   apiFetchDotbots,
   apiFetchMapSize,
@@ -64,32 +63,66 @@ const RestApp: React.FC = () => {
     log.info(`Publishing message: ${message} to topic: ${topic}`);
   }, []);
 
-  const onWsOpen = (): void => {
-    log.info('websocket opened');
-    fetchDotBots();
-  };
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const connectWebSocketRef = useRef<() => void>(() => {});
 
-  const onWsMessage = (event: MessageEvent): void => {
-    const message: WsMessage = JSON.parse(event.data as string);
-    if (message.cmd === NotificationType.Reload) {
+  const openWebSocket = useCallback(() => {
+    if (wsRef.current && wsRef.current.readyState !== WebSocket.CLOSED) {
+      return;
+    }
+
+    const ws = new WebSocket(websocketUrl);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      log.info('websocket opened');
       fetchDotBots();
-    }
-    if (message.cmd === NotificationType.NewDotBot) {
-      setDotbots(prev => [...prev, message.data as DotBot]);
-    }
-    if (message.cmd === NotificationType.Update && dotbots && dotbots.length > 0) {
-      setDotbots(prev => handleDotBotUpdate(prev, message));
-    }
-  };
+    };
 
-  useWebSocket(websocketUrl, {
-    onOpen: () => onWsOpen(),
-    onClose: () => log.warn("websocket closed"),
-    onMessage: (event) => onWsMessage(event),
-    shouldReconnect: () => true,
-    reconnectInterval: (attempt) => Math.min(500 * 2 ** attempt, 10000),
-    filter: () => false,
-  });
+    ws.onclose = () => {
+      log.warn("websocket closed");
+      reconnectTimerRef.current = setTimeout(() => connectWebSocketRef.current(), 1000);
+    };
+
+    ws.onmessage = (event: MessageEvent) => {
+      const message: WsMessage = JSON.parse(event.data as string);
+      if (message.cmd === NotificationType.Reload) {
+        fetchDotBots();
+      }
+      if (message.cmd === NotificationType.NewDotBot) {
+        setDotbots(prev => [...prev, message.data as DotBot]);
+      }
+      if (message.cmd === NotificationType.Update) {
+        setDotbots(prev => prev.length > 0 ? handleDotBotUpdate(prev, message) : prev);
+      }
+    };
+  }, [fetchDotBots, websocketUrl]);
+
+  const connectWebSocket = useCallback(() => {
+    apiFetchDotbots()
+      .then(data => {
+        if (data) setDotbots(data);
+        openWebSocket();
+      })
+      .catch(() => {
+        reconnectTimerRef.current = setTimeout(() => connectWebSocketRef.current(), 1000);
+      });
+  }, [openWebSocket]);
+
+  useEffect(() => {
+    connectWebSocketRef.current = connectWebSocket;
+  }, [connectWebSocket]);
+
+  useEffect(() => {
+    connectWebSocket();
+    return () => {
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+      }
+      wsRef.current?.close();
+    };
+  }, [connectWebSocket]);
 
   useEffect(() => {
     if (!dotbots) {

--- a/dotbot/frontend/src/utils/helpers.ts
+++ b/dotbot/frontend/src/utils/helpers.ts
@@ -101,7 +101,7 @@ export const handleDotBotUpdate = (prevList: DotBot[], message: WsMessage): DotB
     }
 
     // battery
-    if (message.data.battery != null && Math.abs((bot.battery ?? 0) - message.data.battery) > 0.1) {
+    if (message.data.battery != null && Math.abs((bot.battery ?? 0) - message.data.battery) > 0.05) {
       updated = { ...updated, battery: message.data.battery };
       botChanged = true;
     }


### PR DESCRIPTION
Similar to #230 which didn't fixed the reconnection delay after a long disconnection period.

The main problem on my local setup was that when the connection is refused repeatedly, Firefox applies its own exponential backoff to WebSocket connection attempts on the same URL . This is independent of any JS-side reconnect logic.
Another issue was that useWebSocket hook was called on every render with freshly-created callback references (no useCallback), which could cause the library to reset its internal state.

So the change is to use a native Websocket instance rather than react-use-websocket and to wrap it in a useRef to ensure there's only a single instance of it.
Before creating the WebSocket instance, the RestApp component performs an HTTP request via apiFetchDotbots. Once the server responds to HTTP, the component tries the websocket connection. This prevents the browser from accumulating backoff against the WebSocket endpoint.

Some unit tests also had to be adapted.