### PR TITLE
DotBot unification: cli scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Python control plane for DotBots. Serial / cloud / edge adapters talk to a DotBot gateway (often via Mari → marilib); a FastAPI REST + WebSocket server exposes state; a React web UI provides joystick/map/lighthouse-position visualization. Also ships CLI tools (`dotbot-controller`, `dotbot-edge-gateway`, `dotbot-keyboard`, `dotbot-joystick`, `dotbot-qrkey`) and DotBot/SailBot simulators.
+Python control plane for DotBots. Serial / cloud / edge adapters talk to a DotBot gateway (often via Mari → marilib); a FastAPI REST + WebSocket server exposes state; a React web UI provides joystick/map/lighthouse-position visualization. Ships a unified `dotbot` CLI (`dotbot controller`, `dotbot testbed`, `dotbot calibrate`, `dotbot demo`, `dotbot keyboard`, `dotbot joystick`, ...) plus DotBot/SailBot simulators. Legacy entry points `dotbot-controller` / `dotbot-keyboard` / `dotbot-joystick` are kept as backwards-compat aliases for one deprecation cycle.
 
 This is the most active repo in the ecosystem (187 commits in last 90 days as of 2026-05-05).
 
@@ -15,7 +15,8 @@ This is the most active repo in the ecosystem (187 commits in last 90 days as of
 
 ## Entry points
 
-- `dotbot/controller_app.py` — main CLI (`dotbot-controller`); wires adapters and settings
+- `dotbot/cli/main.py` — unified `dotbot` Click group (lazy subcommand loader)
+- `dotbot/controller_app.py` — `dotbot controller` subcommand backend; wires adapters and settings
 - `dotbot/controller.py:1` — 737-line `Controller` class; central object
 - `dotbot/frontend/src/App.tsx` — React UI root
 
@@ -23,8 +24,11 @@ This is the most active repo in the ecosystem (187 commits in last 90 days as of
 
 ```bash
 pip install pydotbot                         # or `pip install -e .`
-dotbot-controller --help
-# Other entry points: dotbot-edge-gateway, dotbot-keyboard, dotbot-joystick, dotbot-qrkey
+dotbot --help               # unified dispatcher
+dotbot controller --help    # start the controller
+dotbot testbed --help       # testbed ops (optional: pip install pydotbot[testbed])
+dotbot calibrate --help     # LH2 calibration (optional: pip install pydotbot[calibrate])
+dotbot demo --list          # built-in research demos
 
 # Tests / lint / build
 tox                                          # envs: tests, check, cli, web=npm run lint, doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to PyDotBot are recorded here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Unified `dotbot` CLI dispatcher that mounts every workflow (controller,
+  sim, testbed ops, calibration, demos, keyboard/joystick) under one
+  command. Subcommand modules are loaded lazily so `dotbot --help` stays
+  cheap.
+- Optional dependency groups: `pip install pydotbot[testbed]` adds
+  `swarmit` + `dotbot-provision`; `pip install pydotbot[calibrate]` adds
+  `dotbot-lh2-calibration`; `pip install pydotbot[all]` pulls all three.
+- `dotbot demo` discoverable launcher; `dotbot demo qr` runs the qrkey
+  phone-bridge demo.
+- `dotbot fw` mock surface (scaffold/build/flash subcommands; placeholder
+  for the firmware-developer workflow).
+
+### Changed
+
+- The qrkey integration moved from `dotbot/qrkey.py` to
+  `dotbot/examples/qrkey_demo/`. The demo is now a separate process that
+  consumes the controller's REST API — the controller stays agnostic to
+  qrkey.
+- `dotbot/examples/qrkey_demo/` is a thin client of the upstream `qrkey`
+  package (now pinned `>= 0.12.2`); none of its code is vendored.
+- Frontend polls qrkey count every 1 s for faster Show QR button
+  feedback.
+
+### Removed
+
+- `dotbot-qrkey` console script — use `python -m dotbot.examples.qrkey_demo`
+  or `dotbot demo qr` instead.
+- `dotbot-edge-gateway` console script — the referenced module
+  `dotbot.edge_gateway_app` never existed; the entry was silently broken.
+- `pin_code` tox env — referenced `dotbot/pin_code_ui/` which never
+  existed.
+
+### Deprecated
+
+- `dotbot-controller`, `dotbot-keyboard`, and `dotbot-joystick` console
+  scripts remain working as backwards-compat aliases for one deprecation
+  cycle. Prefer `dotbot <subcommand>` for new code.

--- a/README.md
+++ b/README.md
@@ -29,66 +29,61 @@ nRF52833DK/nRF52840DK/nrf5340DK board as gateway), as explained in
 
 ## Usage
 
+A single `dotbot` CLI dispatches to every workflow — controller,
+testbed ops, calibration, demos:
+
 ```
-dotbot-controller --help
-Usage: dotbot-controller [OPTIONS]
+dotbot --help
+Usage: dotbot [OPTIONS] COMMAND [ARGS]...
 
-  DotBotController, universal SailBot and DotBot controller.
+  Control DotBots: drive robots, run testbed experiments, calibrate, demos.
 
-Options:
-  -a, --adapter [serial|edge|cloud|dotbot-simulator|sailbot-simulator]
-                                  Controller interface adapter. Defaults to
-                                  serial
-  -p, --port TEXT                 Serial port used by 'serial' and 'edge'
-                                  adapters. Defaults to '/dev/ttyACM0'
-  -b, --baudrate INTEGER          Serial baudrate used by 'serial' and 'edge'
-                                  adapters. Defaults to 1000000
-  -H, --mqtt-host TEXT            MQTT host used by cloud adapter. Default:
-                                  localhost.
-  -P, --mqtt-port INTEGER         MQTT port used by cloud adapter. Default:
-                                  1883.
-  -T, --mqtt-use_tls / --no-mqtt-use_tls
-                                  Use TLS with MQTT (for cloud adapter).
-  -g, --gw-address TEXT           Gateway address in hex. Defaults to
-                                  0000000000000000
-  -s, --network-id TEXT           Network ID in hex. Defaults to 0000
-  -c, --controller-http-port INTEGER
-                                  Controller HTTP port of the REST API. Defaults
-                                  to '8000'
-  -w, --webbrowser / --no-webbrowser
-                                  Open a web browser automatically
-  -v, --verbose                   Run in verbose mode (all payloads received are
-                                  printed in terminal)
-  --log-level [debug|info|warning|error]
-                                  Logging level. Defaults to info
-  --log-output PATH               Filename where logs are redirected
-  --config-path FILE              Path to a .toml configuration file.
-  -m, --map-size TEXT             Map size in mm. Defaults to '2000x2000'
-  --help                          Show this message and exit.
+Commands:
+  controller  Start the controller (adapter + REST/WS + dashboard).
+  sim         Standalone simulator (equivalent to controller --adapter dotbot-simulator).
+  testbed     Testbed-side ops: provision, status, start/stop, OTA flash, monitor.
+  calibrate   Run the LH2 calibration workflow.
+  demo        Built-in research demos (qrkey phone bridge, ...).
+  fw          Firmware-developer workflow (scaffold/build/flash). Not yet implemented.
+  keyboard    Drive a DotBot from the keyboard (live).
+  joystick    Drive a DotBot from a joystick (live).
 ```
 
-By default, the controller expects the serial port to be `/dev/ttyACM0`, as on
-Linux, use the `--port` option to specify another one if it's different. For
-example, on Windows, you'll need to check which COM port is connected to the
-gateway and add `--port COM3` if it's COM3.
+The `testbed`, `calibrate`, and some `demo` subcommands need optional
+backends installed:
 
-Using the `--webbrowser` option, a tab will automatically open at
-[http://localhost:8000/PyDotBot](http://localhost:8000/PyDotBot). The page maintains
-a list of available DotBots, allows to set which one is selected and controllable
-and provide a virtual joystick to control it or change the color of the on-board
-RGB LED.
+```
+pip install pydotbot[testbed]    # adds swarmit + dotbot-provision
+pip install pydotbot[calibrate]  # adds dotbot-lh2-calibration
+pip install pydotbot[all]        # all of the above
+```
 
-Use `--config-path` to specify the file:
+### Starting the controller
+
+Run `dotbot controller --help` for the full flag list (adapter, MQTT,
+HTTP port, map size, etc.). By default the controller expects the serial
+port to be `/dev/ttyACM0` on Linux — use `--port` to override (e.g.
+`--port COM3` on Windows).
+
+With `--webbrowser`, a tab opens at
+[http://localhost:8000/PyDotBot](http://localhost:8000/PyDotBot). The
+page lists available DotBots, lets you select and control one, and
+exposes a virtual joystick and RGB LED control.
+
+Use `--config-path` for a TOML config file:
 
 ```bash
 # Use settings from the config file
-dotbot-controller --config-path config_sample.toml
+dotbot controller --config-path config_sample.toml
 # Use config file but override port and adapter (simulator example)
-dotbot-controller --config-path config_sample.toml -a dotbot-simulator
+dotbot controller --config-path config_sample.toml -a dotbot-simulator
 ```
 
-Values defined in the config file behave exactly like CLI options.
-If both are provided, CLI flags override config values.
+CLI flags override config-file values when both are provided.
+
+The legacy `dotbot-controller`, `dotbot-keyboard`, and `dotbot-joystick`
+console scripts remain as backwards-compatible aliases for one
+deprecation cycle. Prefer `dotbot <subcommand>` for new code.
 
 **Firefox users:**
 If the webapp is not working, press `Ctrl + L`, type `about:config`,

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -36,12 +36,12 @@ DotBot(s).
   If using an nRF5340DK, you might see 2 TTY port, use the one with the lowest
   id.
 
-3. From a terminal window (or powershell on Windows), run `dotbot-controller`
+3. From a terminal window (or powershell on Windows), run `dotbot controller`
   with the TTY port you identified above and the `--webbrowser` flag to
   automatically open the web client:
 
 ```
-dotbot-controller --port <tty port> --webbrowser
+dotbot controller --port <tty port> --webbrowser
 ```
 
 At this point, if the DotBot is powered on with fully charged batteries, you
@@ -84,7 +84,7 @@ Welcome to the DotBots controller (version: 0.xx).
     the DotBot to move
   - by using the color selector in the UI
 
-5. In a separate command window, launch `dotbot-keyboard`:
+5. In a separate command window, launch `dotbot keyboard`:
 ```
 Welcome to the DotBots keyboard interface (version: 0.16).
 2023-12-08T10:07:32.597536Z [info     ] Controller initialized         [pydotbot] context=dotbot.keyboard

--- a/doc/mqtt.md
+++ b/doc/mqtt.md
@@ -42,7 +42,7 @@ change and recomputes (or rederive) their key/topic accordingly.
 ## Prerequisites
 
 Make sure you already followed the [getting started](getting_started) page and
-have a functional setup with `dotbot-controller` running and connected to a
+have a functional setup with `dotbot controller` running and connected to a
 nRF DK gateway.
 
 To interact with the MQTT broker, you will use a Python script that require
@@ -65,7 +65,7 @@ pip install cryptography joserfc paho-mqtt requests
 Running the controller is as easy as running the following command:
 
 ```
-dotbot-controller
+dotbot controller
 ```
 
 The logs should contain information about the MQTT broker connection and the

--- a/doc/rest.md
+++ b/doc/rest.md
@@ -1,10 +1,10 @@
 # REST
 
-While connected to a DotBot gateway, the `dotbot-controller`
+While connected to a DotBot gateway, the `dotbot controller`
 application provides a REST server to send commands to and receive information
 from connected DotBots.
 
-The REST API is documented in the running `dotbot-controller` application itself
+The REST API is documented in the running `dotbot controller` application itself
 at [http://localhost:8000/api](http://localhost:8000/api). This page also allows
 you to play with the API directly from the browser.
 
@@ -18,7 +18,7 @@ you to play with the API directly from the browser.
 ## Prerequisites
 
 Make sure you already followed the [getting started](getting_started) page and
-have a functional setup with `dotbot-controller` running and connected to a
+have a functional setup with `dotbot controller` running and connected to a
 nRF DK gateway.
 
 To interact with the REST API, you will use the Python
@@ -66,7 +66,7 @@ If a DotBot is connected, this script should give an output similar to:
 ]
 ```
 
-This is a list of all DotBots connected to the `dotbot-controller`. In the
+This is a list of all DotBots connected to the `dotbot controller`. In the
 example above, there is only one DotBot connected.
 The 8-byte `address` uniquely identifies a DotBot in the controller. The
 `status` indicates whether the DotBot is `Active` (value=0, the DotBot has been

--- a/dotbot/cli/__init__.py
+++ b/dotbot/cli/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unified `dotbot` CLI dispatcher.
+
+See plans/dotbot-unified-dx.md (Phase 1) for the design rationale.
+The dispatcher mounts existing Click commands from this package and
+sibling packages (swarmit, dotbot-lh2-calibration) as subcommands so
+users see one tool instead of seven console_scripts.
+"""
+
+from dotbot.cli.main import cli  # noqa: F401

--- a/dotbot/cli/__main__.py
+++ b/dotbot/cli/__main__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Allow `python -m dotbot.cli` (and `python -m dotbot`)."""
+
+from dotbot.cli.main import cli
+
+if __name__ == "__main__":
+    cli()  # pragma: no cover, pylint: disable=no-value-for-parameter

--- a/dotbot/cli/_lazy.py
+++ b/dotbot/cli/_lazy.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Helper for mounting subcommands that live in optional sibling packages.
+
+Each subcommand sits behind a `pip install dotbot[<extra>]` boundary so
+the core install stays lean. When the extra is missing we still want
+`dotbot --help` to list the subcommand (so users see what exists) and
+running it should print an actionable install hint instead of a
+traceback.
+"""
+
+import sys
+from typing import Callable, Optional
+
+import click
+
+
+def lazy_subcommand(
+    *,
+    name: str,
+    extra: str,
+    package: str,
+    help: str,
+    loader: Callable[[], click.Command],
+) -> click.Command:
+    """Return a Click command that defers import until invocation.
+
+    If `loader()` raises ImportError, we expose a stub group/command
+    that prints a clean install hint and exits 1. The stub keeps the
+    name visible in `dotbot --help` so missing extras are discoverable.
+    """
+    try:
+        cmd = loader()
+    except ImportError as exc:
+        return _missing_extra_stub(
+            name=name, extra=extra, package=package, help=help, error=str(exc)
+        )
+
+    # Don't mutate cmd.name — the source package has its own tests that
+    # assert on the original name. Click uses the lookup-key name from
+    # the parent's `commands` dict for usage display, so the dispatcher
+    # still shows e.g. `Usage: dotbot testbed ...` correctly.
+    return cmd
+
+
+def _missing_extra_stub(
+    *, name: str, extra: str, package: str, help: str, error: Optional[str]
+) -> click.Command:
+    @click.command(
+        name=name,
+        help=f"{help} [install: pip install dotbot[{extra}]]",
+        context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
+    )
+    @click.pass_context
+    def _stub(ctx):  # pylint: disable=unused-argument
+        click.echo(
+            f"`dotbot {name}` needs the `{package}` package "
+            f"(not installed in this environment).",
+            err=True,
+        )
+        click.echo(f"Install with:  pip install dotbot[{extra}]", err=True)
+        if error:
+            click.echo(f"(import error was: {error})", err=True)
+        sys.exit(1)
+
+    return _stub

--- a/dotbot/cli/calibrate.py
+++ b/dotbot/cli/calibrate.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""`dotbot calibrate` — LH2 calibration TUI.
+
+Phase 1 mounts `dotbot-lh2-calibration`'s Click command verbatim.
+Phase 5 vendors the package into `dotbot/calibration/` and adds a
+dashboard tab.
+"""
+
+from dotbot.cli._lazy import lazy_subcommand
+
+
+def _load():
+    from dotbot_lh2_calibration.calibration_cli import main as calibrate_cmd
+
+    return calibrate_cmd
+
+
+cmd = lazy_subcommand(
+    name="calibrate",
+    extra="calibrate",
+    package="dotbot-lh2-calibration",
+    help="Run the LH2 calibration workflow (Textual TUI).",
+    loader=_load,
+)

--- a/dotbot/cli/controller.py
+++ b/dotbot/cli/controller.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""`dotbot controller` — start the controller + REST/WS + dashboard.
+
+Today this re-mounts the existing `dotbot.controller_app:main` Click
+command verbatim. Future phases (see plans/dotbot-unified-dx.md
+Phase 4) extract the engine from the controller monolith.
+"""
+
+from dotbot.controller_app import main as _controller_main
+
+# Re-export the existing command without mutation. The dispatcher
+# registers it under name="controller"; Click's usage formatter uses
+# that lookup name, not cmd.name, so we don't need to rewrite it.
+cmd = _controller_main

--- a/dotbot/cli/demo.py
+++ b/dotbot/cli/demo.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""`dotbot demo` — discoverable launcher for built-in research demos.
+
+Demos live in `dotbot/examples/`. Each demo is a Level-3 consumer of
+the controller's REST/WS API (see the access-levels architecture in
+plans/dotbot-consolidation-roadmap.md). Adding a new demo means
+dropping a Click command somewhere under `dotbot/examples/` and
+registering it below.
+"""
+
+import click
+
+from dotbot.examples.qrkey_demo.cli import main as _qrkey_main
+
+
+@click.group(
+    name="demo",
+    help="Built-in research demos (qrkey phone bridge, formations, ...).",
+    invoke_without_command=True,
+)
+@click.option(
+    "--list",
+    "list_demos",
+    is_flag=True,
+    help="List available demos.",
+)
+@click.pass_context
+def cmd(ctx, list_demos):
+    if list_demos or ctx.invoked_subcommand is None:
+        click.echo("Available demos:")
+        for name, sub in cmd.commands.items():
+            short = (sub.help or "").splitlines()[0] if sub.help else ""
+            click.echo(f"  {name:<12} {short}")
+        click.echo("")
+        click.echo("Run one with: dotbot demo <name> [OPTIONS]")
+        ctx.exit(0)
+
+
+# Register demos. New entries go here. Keep the alias short (the
+# subcommand IS the discovery surface — long names defeat the point).
+# We pass `name=...` rather than mutating `_qrkey_main.name` so the
+# demo's own test suite (which imports the same Click command) stays
+# unaffected.
+cmd.add_command(_qrkey_main, name="qr")

--- a/dotbot/cli/fw.py
+++ b/dotbot/cli/fw.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""`dotbot fw` — firmware-developer workflow (mocked in Phase 1).
+
+The CLI surface is wired so the help text is discoverable today, but
+the underlying build/flash/template machinery doesn't exist yet — it
+depends on a C toolchain pipeline (cmake + ninja + gcc-arm-none-eabi)
+and app templates that the firmware unification plan delivers.
+
+See plans/dotbot-firmware-unification.md (Track B Phase 2 + Phase 5).
+"""
+
+import sys
+
+import click
+
+_NOT_READY = (
+    "`dotbot fw {sub}` is not implemented yet.\n"
+    "Tracking: plans/dotbot-firmware-unification.md (Track B Phase 2 + Phase 5).\n"
+    "For now: use SEGGER Embedded Studio or the per-target Makefile in "
+    "`DotBot-firmware` / `dotbot-swarmit` / `dotbot-lh2-calibration`."
+)
+
+
+@click.group(
+    name="fw",
+    help=(
+        "Firmware-developer workflow: scaffold, build, USB-cable flash. "
+        "MOCK in Phase 1 — see plans/dotbot-firmware-unification.md."
+    ),
+)
+def cmd():
+    pass
+
+
+@cmd.command()
+@click.argument("name")
+@click.option(
+    "--template",
+    type=click.Choice(["swarmit-app", "bare"]),
+    default="swarmit-app",
+    show_default=True,
+)
+def new(name, template):  # pylint: disable=unused-argument
+    """Scaffold a new firmware project (NOT IMPLEMENTED)."""
+    click.echo(_NOT_READY.format(sub="new"), err=True)
+    sys.exit(2)
+
+
+@cmd.command()
+@click.option("--target", type=str, help="Build target (e.g. dotbot-v3).")
+def build(target):  # pylint: disable=unused-argument
+    """Build firmware via cmake+ninja (NOT IMPLEMENTED)."""
+    click.echo(_NOT_READY.format(sub="build"), err=True)
+    sys.exit(2)
+
+
+@cmd.command()
+@click.argument("image", type=click.Path())
+@click.option("--serial", type=str, help="J-Link / nRF serial number.")
+@click.option("--bare/--swarmit", default=False, help="Bypass swarmit sandbox.")
+@click.option(
+    "--component",
+    type=click.Choice(["app", "bootloader", "netcore"]),
+    default="app",
+    show_default=True,
+)
+@click.option("--gateway", is_flag=True, help="Flash a gateway bot.")
+def flash(image, serial, bare, component, gateway):  # pylint: disable=unused-argument
+    """USB-cable flash an image to a single bot (NOT IMPLEMENTED)."""
+    click.echo(_NOT_READY.format(sub="flash"), err=True)
+    sys.exit(2)

--- a/dotbot/cli/joystick.py
+++ b/dotbot/cli/joystick.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""`dotbot joystick` — drive a bot live from a USB joystick."""
+
+from dotbot.joystick import main as _joystick_main
+
+cmd = _joystick_main

--- a/dotbot/cli/keyboard.py
+++ b/dotbot/cli/keyboard.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""`dotbot keyboard` — drive a bot live from the keyboard."""
+
+from dotbot.keyboard import main as _keyboard_main
+
+cmd = _keyboard_main

--- a/dotbot/cli/main.py
+++ b/dotbot/cli/main.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Root `dotbot` Click group with lazy subcommand loading.
+
+Each subcommand lives in its own module under `dotbot.cli.<name>` and
+exposes a `cmd` attribute. The root group lists subcommand names
+eagerly (so `dotbot --help` is cheap) but only imports a subcommand's
+module when the subcommand is actually invoked.
+
+Why lazy: importing `dotbot.controller_app` pulls in `dotbot.server`
+which mounts FastAPI StaticFiles at module load — fine for the
+controller subcommand, but `dotbot fw --help` shouldn't pay that cost
+(or fail when the frontend bundle isn't built).
+
+Adding a new subcommand:
+  1. Create `dotbot/cli/<name>.py` exposing `cmd = click.Command(...)`.
+  2. Add an entry to `_SUBCOMMANDS` below: (cli-name, module path,
+     short help string shown in `dotbot --help`).
+  3. If the backend lives in an optional sibling package, use
+     `dotbot.cli._lazy.lazy_subcommand` inside that module.
+"""
+
+import importlib
+from typing import Optional, Tuple
+
+import click
+
+from dotbot import pydotbot_version
+
+# (cli-name, dotted module path, short help shown by `dotbot --help`)
+_SUBCOMMANDS: Tuple[Tuple[str, str, str], ...] = (
+    (
+        "controller",
+        "dotbot.cli.controller",
+        "Start the controller (adapter + REST/WS + dashboard).",
+    ),
+    (
+        "sim",
+        "dotbot.cli.sim",
+        "Standalone simulator (equivalent to controller --adapter dotbot-simulator).",
+    ),
+    (
+        "testbed",
+        "dotbot.cli.testbed",
+        "Testbed-side ops: provision, status, start/stop, OTA flash, monitor.",
+    ),
+    ("calibrate", "dotbot.cli.calibrate", "Run the LH2 calibration workflow."),
+    ("demo", "dotbot.cli.demo", "Built-in research demos (qrkey phone bridge, ...)."),
+    (
+        "fw",
+        "dotbot.cli.fw",
+        "Firmware-developer workflow (scaffold/build/flash). MOCK in Phase 1.",
+    ),
+    ("keyboard", "dotbot.cli.keyboard", "Drive a DotBot from the keyboard (live)."),
+    ("joystick", "dotbot.cli.joystick", "Drive a DotBot from a joystick (live)."),
+)
+
+_HELP_INDEX = {name: short for name, _, short in _SUBCOMMANDS}
+_MODULE_INDEX = {name: module_path for name, module_path, _ in _SUBCOMMANDS}
+
+
+class _LazyGroup(click.Group):
+    """Click group that resolves subcommands by importing on demand."""
+
+    def list_commands(self, ctx):
+        return [name for name, _, _ in _SUBCOMMANDS]
+
+    def get_command(self, ctx, cmd_name) -> Optional[click.Command]:
+        module_path = _MODULE_INDEX.get(cmd_name)
+        if module_path is None:
+            return None
+        module = importlib.import_module(module_path)
+        return module.cmd
+
+    def format_commands(self, ctx, formatter):
+        """Render `dotbot --help` from the static help-string table.
+
+        Overriding this avoids importing each subcommand module just to
+        pull its short help line — that would defeat the lazy load.
+        """
+        rows = [(name, _HELP_INDEX[name]) for name, _, _ in _SUBCOMMANDS]
+        if rows:
+            with formatter.section("Commands"):
+                formatter.write_dl(rows)
+
+
+@click.group(
+    cls=_LazyGroup,
+    help="Control DotBots: drive robots, run testbed experiments, calibrate, demos.",
+)
+@click.version_option(
+    version=pydotbot_version(),
+    prog_name="dotbot",
+    message="%(prog)s %(version)s",
+)
+def cli():
+    pass

--- a/dotbot/cli/sim.py
+++ b/dotbot/cli/sim.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""`dotbot sim` — standalone simulator (no hardware).
+
+Equivalent to `dotbot controller --adapter dotbot-simulator`. The name
+advertises the no-hardware case so students can discover the offline
+path from `dotbot --help` without reading adapter docs.
+
+Phase 1 implementation: prepend `--adapter dotbot-simulator` to argv
+and delegate to the controller's Click command. Phase 3 turns this
+into a first-class entry that wires Engine + SimulatorAdapter directly
+(see plans/dotbot-unified-dx.md).
+"""
+
+import click
+
+from dotbot.controller_app import main as _controller_main
+
+
+@click.command(
+    name="sim",
+    context_settings=dict(
+        ignore_unknown_options=True,
+        allow_extra_args=True,
+        help_option_names=[],  # forward --help to the controller
+    ),
+    add_help_option=False,
+)
+@click.pass_context
+def cmd(ctx):
+    """Run a standalone simulator (no hardware required).
+
+    All other controller flags are forwarded as-is. Try
+    `dotbot sim --help` for the full option list.
+    """
+    args = ["--adapter", "dotbot-simulator", *ctx.args]
+    _controller_main.main(args=args, standalone_mode=True)

--- a/dotbot/cli/testbed.py
+++ b/dotbot/cli/testbed.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""`dotbot testbed` — provision, OTA-flash, start/stop/monitor.
+
+Phase 1 mounts the upstream `swarmit` Click group verbatim under the
+new name. Users get `dotbot testbed status|start|stop|flash|monitor|
+reset|message|calibrate-lh2` with the same flags they have today.
+
+The `provision` subcommand (one-time bootloader/netcore bringup) is
+mounted from `dotbot-provision`. See plans/dotbot-unified-dx.md for
+the long-term plan to fold both into `dotbot/testbed/`.
+"""
+
+from dotbot.cli._lazy import lazy_subcommand
+
+
+def _load_swarmit_group():
+    from swarmit.cli.main import main as swarmit_group
+
+    return swarmit_group
+
+
+def _load_provision_group():
+    from dotbot_provision.cli import cli as provision_group
+
+    return provision_group
+
+
+cmd = lazy_subcommand(
+    name="testbed",
+    extra="testbed",
+    package="swarmit",
+    help=(
+        "Testbed-side ops: provision, status, start/stop/monitor, OTA-flash. "
+        "Wraps swarmit + dotbot-provision today; folds inline in Phase 6."
+    ),
+    loader=_load_swarmit_group,
+)
+
+# Best-effort: if both swarmit and dotbot-provision are installed, mount
+# provision as a subgroup of testbed so the layout matches the planned
+# `dotbot testbed provision ...` UX. If either is missing the stub above
+# already handled the user message.
+try:
+    import click  # noqa: F401  (guard the attach below)
+
+    if hasattr(cmd, "commands"):
+        try:
+            provision_group = _load_provision_group()
+            cmd.add_command(provision_group, name="provision")
+        except ImportError:
+            # provision extra not installed; testbed itself still works.
+            pass
+except Exception:  # pylint: disable=broad-except
+    pass

--- a/dotbot/tests/test_cli_dispatcher.py
+++ b/dotbot/tests/test_cli_dispatcher.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the `dotbot` CLI dispatcher.
+
+Goal: lock the discovery surface (subcommand list + --help) so a
+future refactor doesn't silently drop a command. We're NOT testing
+the underlying subcommand behavior here — that lives in each
+subcommand's own test module (test_controller_app.py etc.).
+"""
+
+import subprocess
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+from dotbot.cli import _lazy
+from dotbot.cli.main import _SUBCOMMANDS, cli
+
+EXPECTED_SUBCOMMANDS = {
+    "controller",
+    "sim",
+    "testbed",
+    "calibrate",
+    "demo",
+    "fw",
+    "keyboard",
+    "joystick",
+}
+
+# Subcommands whose --help backends live in OTHER packages with their
+# own protocol registries (swarmit, dotbot-lh2-calibration). When
+# pytest pre-loads dotbot.protocol via test_controller etc., importing
+# those packages in the same process triggers a duplicate payload-type
+# registration (ValueError 0x81 already registered). This is the known
+# cross-package protocol duplication captured in the consolidation
+# roadmap §1; it never happens in real `dotbot <sub>` invocations
+# (each shell run is a fresh process). We verify these in a subprocess.
+_CROSS_PACKAGE_SUBS = {"testbed", "calibrate"}
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_root_help_lists_every_subcommand(runner):
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0, result.output
+    for name in EXPECTED_SUBCOMMANDS:
+        assert name in result.output, f"subcommand `{name}` missing from --help"
+
+
+def test_subcommand_table_matches_expected_set():
+    """The static `_SUBCOMMANDS` tuple is the wiring contract."""
+    declared = {name for name, _, _ in _SUBCOMMANDS}
+    assert declared == EXPECTED_SUBCOMMANDS
+
+
+def test_version_flag(runner):
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert "dotbot" in result.output
+
+
+@pytest.mark.parametrize(
+    "subcommand",
+    sorted(EXPECTED_SUBCOMMANDS - {"keyboard", "joystick"} - _CROSS_PACKAGE_SUBS),
+)
+def test_subcommand_help_works(runner, subcommand):
+    """Every in-process subcommand's --help runs cleanly.
+
+    keyboard/joystick are excluded because they import pygame/pynput at
+    module load time (headless-CI hostile). testbed/calibrate are
+    excluded because their backends collide with PyDotBot's protocol
+    registry inside a single pytest process — covered separately by
+    test_cross_package_subcommand_help_works in a subprocess.
+    """
+    result = runner.invoke(cli, [subcommand, "--help"])
+    assert result.exit_code == 0, result.output
+
+
+@pytest.mark.parametrize("subcommand", sorted(_CROSS_PACKAGE_SUBS))
+def test_cross_package_subcommand_help_works(subcommand):
+    """`dotbot testbed --help` / `dotbot calibrate --help` in a clean process.
+
+    A subprocess avoids the swarmit/lh2-calibration vs PyDotBot
+    protocol-registry collision that only manifests inside pytest's
+    shared-process test session. See _CROSS_PACKAGE_SUBS comment above.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "dotbot.cli", subcommand, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    # Sanity: the help text should mention the subcommand or its purpose.
+    combined = result.stdout + result.stderr
+    assert "Usage" in combined
+
+
+def test_fw_mock_exits_nonzero(runner):
+    """fw stubs must surface that they're not implemented (exit 2)."""
+    result = runner.invoke(cli, ["fw", "new", "myapp"])
+    assert result.exit_code == 2
+    assert "not implemented" in result.output.lower()
+
+
+def test_demo_list(runner):
+    """`dotbot demo --list` enumerates demos including `qr`."""
+    result = runner.invoke(cli, ["demo", "--list"])
+    assert result.exit_code == 0
+    assert "qr" in result.output
+
+
+def test_demo_default_lists(runner):
+    """`dotbot demo` with no subcommand also lists (discoverability)."""
+    result = runner.invoke(cli, ["demo"])
+    assert result.exit_code == 0
+    assert "qr" in result.output
+
+
+def test_lazy_subcommand_missing_extra_exits_with_hint():
+    """A subcommand whose backend isn't installed prints an install hint."""
+
+    def loader():
+        raise ImportError("simulated missing dep")
+
+    stub = _lazy.lazy_subcommand(
+        name="fake",
+        extra="fake-extra",
+        package="fake-pkg",
+        help="A fake subcommand for the test.",
+        loader=loader,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(stub, [])
+    assert result.exit_code == 1
+    assert "pip install dotbot[fake-extra]" in result.output
+    assert "fake-pkg" in result.output
+
+
+def test_python_m_dotbot_cli_entrypoint(runner):
+    """`python -m dotbot.cli` must dispatch through the same group."""
+    # The __main__ module's behavior is tested by importing and asserting
+    # it references the same cli object — running it as a subprocess
+    # would slow tests down without adding coverage.
+    from dotbot.cli import __main__ as cli_main_module
+
+    assert cli_main_module.cli is cli

--- a/dotbot/tests/test_cli_dispatcher.py
+++ b/dotbot/tests/test_cli_dispatcher.py
@@ -9,6 +9,7 @@ the underlying subcommand behavior here — that lives in each
 subcommand's own test module (test_controller_app.py etc.).
 """
 
+import os
 import subprocess
 import sys
 
@@ -17,6 +18,28 @@ from click.testing import CliRunner
 
 from dotbot.cli import _lazy
 from dotbot.cli.main import _SUBCOMMANDS, cli
+
+# Importing dotbot.controller (transitively, dotbot.server) blows up at
+# module-import time if the React UI hasn't been built — FastAPI's
+# StaticFiles mount asserts the directory exists. That's a pre-existing
+# import-time side effect, not something the CLI scaffold introduced.
+# Skip the subcommands whose lazy import triggers it when the bundle
+# isn't built (typical for fresh editable installs).
+_FRONTEND_BUILD = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "frontend",
+    "build",
+)
+_FRONTEND_PRESENT = os.path.isdir(_FRONTEND_BUILD)
+_needs_frontend = pytest.mark.skipif(
+    not _FRONTEND_PRESENT,
+    reason=(
+        "frontend bundle missing — run `cd dotbot/frontend && npm run build`. "
+        "The CLI scaffold itself does not depend on the bundle; this skip "
+        "exists because dotbot.server.api.mount(StaticFiles) runs at import."
+    ),
+)
+
 
 EXPECTED_SUBCOMMANDS = {
     "controller",
@@ -64,6 +87,9 @@ def test_version_flag(runner):
     assert "dotbot" in result.output
 
 
+_FRONTEND_DEPENDENT = {"controller", "sim"}
+
+
 @pytest.mark.parametrize(
     "subcommand",
     sorted(EXPECTED_SUBCOMMANDS - {"keyboard", "joystick"} - _CROSS_PACKAGE_SUBS),
@@ -76,7 +102,13 @@ def test_subcommand_help_works(runner, subcommand):
     excluded because their backends collide with PyDotBot's protocol
     registry inside a single pytest process — covered separately by
     test_cross_package_subcommand_help_works in a subprocess.
+    controller/sim trigger dotbot.server's StaticFiles import-time mount;
+    skipped if the frontend bundle hasn't been built.
     """
+    if subcommand in _FRONTEND_DEPENDENT and not _FRONTEND_PRESENT:
+        pytest.skip(
+            "frontend bundle missing; run `cd dotbot/frontend && npm run build`"
+        )
     result = runner.invoke(cli, [subcommand, "--help"])
     assert result.exit_code == 0, result.output
 
@@ -145,9 +177,51 @@ def test_lazy_subcommand_missing_extra_exits_with_hint():
 
 def test_python_m_dotbot_cli_entrypoint(runner):
     """`python -m dotbot.cli` must dispatch through the same group."""
-    # The __main__ module's behavior is tested by importing and asserting
-    # it references the same cli object — running it as a subprocess
-    # would slow tests down without adding coverage.
+    # In-process check that the __main__ module routes to the same group.
     from dotbot.cli import __main__ as cli_main_module
 
     assert cli_main_module.cli is cli
+
+
+def test_python_m_dotbot_cli_help_subprocess():
+    """End-to-end: `python -m dotbot.cli --help` runs in a fresh process."""
+    result = subprocess.run(
+        [sys.executable, "-m", "dotbot.cli", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    for name in EXPECTED_SUBCOMMANDS:
+        assert name in result.stdout, f"`{name}` missing from `python -m` help"
+
+
+def test_python_m_dotbot_cli_version_subprocess():
+    """End-to-end: `python -m dotbot.cli --version` prints a version line."""
+    result = subprocess.run(
+        [sys.executable, "-m", "dotbot.cli", "--version"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert "dotbot" in result.stdout
+
+
+@_needs_frontend
+def test_legacy_console_scripts_still_resolve():
+    """Backwards-compat aliases (dotbot-controller, dotbot-keyboard,
+    dotbot-joystick) must still resolve to importable Click commands.
+
+    Checks the entry-point targets via direct import. Skipped without
+    the frontend bundle because dotbot.controller_app pulls in
+    dotbot.server which mounts StaticFiles at import.
+    """
+    import click
+
+    from dotbot.controller_app import main as controller_main
+    from dotbot.joystick import main as joystick_main
+    from dotbot.keyboard import main as keyboard_main
+
+    for cmd in (controller_main, keyboard_main, joystick_main):
+        assert isinstance(cmd, click.Command), f"{cmd!r} is not a Click cmd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,13 +67,47 @@ classifiers = [
 "Bug Tracker" = "https://github.com/DotBots/PyDotBot/issues"
 
 [project.scripts]
+# Unified dispatcher — the future. See plans/dotbot-unified-dx.md.
+dotbot = "dotbot.cli.main:cli"
+
+# Legacy entry points kept as backwards-compat aliases for one release.
+# They will be removed once external scripts have migrated to
+# `dotbot <subcommand>`. Tracked in plans/dotbot-unified-dx.md Phase 1.
 dotbot-controller = "dotbot.controller_app:main"
-dotbot-edge-gateway = "dotbot.edge_gateway_app:main"
 dotbot-keyboard = "dotbot.keyboard:main"
 dotbot-joystick = "dotbot.joystick:main"
+# dotbot-edge-gateway dropped: dotbot.edge_gateway_app does not exist
+# (silent breakage on main as of 2026-05). Workspace AGENTS.md flagged.
 # dotbot-qrkey console script removed — the demo is now an example,
 # run via `python -m dotbot.examples.qrkey_demo`. See
 # dotbot/examples/qrkey_demo/README.md.
+
+[project.optional-dependencies]
+# Lazy-loaded subcommand backends. Keep the core install lean; opt in
+# to the bits you actually use. Pins set conservatively against the
+# installed-in-the-testbed-as-of-2026-05 versions; bump as upstream
+# ships breaking changes.
+testbed = [
+    "swarmit          >= 0.6.0",
+    "dotbot-provision >= 0.1.5",
+]
+calibrate = [
+    "dotbot-lh2-calibration >= 0.2.0",
+]
+all = [
+    "swarmit                >= 0.6.0",
+    "dotbot-provision       >= 0.1.5",
+    "dotbot-lh2-calibration >= 0.2.0",
+]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "ruff",
+    "black",
+    "isort",
+    "pre-commit",
+]
 
 [tool.ruff]
 lint.select = ["E", "F"]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ isolated_build = true
 allowlist_externals =
     cli:   {[testenv:cli]allowlist_externals}
     web:   {[testenv:web]allowlist_externals}
-    pin_code:   {[testenv:pin_code]allowlist_externals}
 commands=
     tests:  {[testenv:tests]commands}
     check:  {[testenv:check]commands}
@@ -50,6 +49,7 @@ allowlist_externals=
     /bin/bash
     /usr/bin/bash
 commands=
+    bash -exc "dotbot --help"
     bash -exc "dotbot-controller --help"
 
 [testenv:web]
@@ -58,11 +58,8 @@ allowlist_externals=
     /usr/bin/bash
 commands = bash -exc "cd dotbot/frontend && npm run lint"
 
-[testenv:pin_code]
-allowlist_externals=
-    /bin/bash
-    /usr/bin/bash
-commands = bash -exc "cd dotbot/pin_code_ui && npm test && npm run lint"
+# pin_code env removed: dotbot/pin_code_ui never existed in the tree —
+# silent dead config flagged in workspace AGENTS.md.
 
 [testenv:format]
 deps=


### PR DESCRIPTION
Unifying all the CLIs from several projects (swarmit, dotbot-provision, calibration, etc) into a single one.

This is the first of a series of PRs, to be merged in the `develop` branch, that aim at a unification and simplification of how users install and use DotBots.