### PR TITLE
dotbot/provision: net_id readback fix + reset-button notice

### DIFF
--- a/dotbot/provision/cli.py
+++ b/dotbot/provision/cli.py
@@ -647,6 +647,11 @@ def cmd_flash(
     click.echo(
         f"[INFO] device_id: {readback_device_id} (last 6 digits: {last_6_digits_spaced})"
     )
+    click.secho(
+        "[NOTE] you may need to press the reset button on the DotBot "
+        "for it to join the network",
+        fg="yellow",
+    )
 
 
 @cli.command("flash-hex", help="Flash explicit app/net hex files.")

--- a/dotbot/provision/nrf_flash.py
+++ b/dotbot/provision/nrf_flash.py
@@ -308,15 +308,21 @@ def read_net_id(snr: str | None = None) -> str:
     )
     args = [nrfjprog, "-f", "NRF53"]
     args += ["--coprocessor", "CP_NETWORK"]
+    # Read both has_net_id (offset 4) and net_id (offset 8) from the swarmit
+    # config page; layout matches swarmit_config_t (see create_config_hex
+    # in cli.py and DotBots/swarmit network_core/Source/main.c).
     args += ["--memrd", "0x0103F804"]
-    args += ["--n", "4"]
+    args += ["--n", "8"]
     if snr:
         args += ["-s", str(snr)]
     out = run_capture(args)
     words = _parse_memrd_words(out)
-    if len(words) < 1:
+    if len(words) < 2:
         raise RuntimeError(f"Unexpected net ID output: {out.strip()}")
-    return f"{words[0][-4:]}"
+    has_net_id, net_id = words[0], words[1]
+    if int(has_net_id, 16) != 1:
+        return "unprovisioned"
+    return f"{net_id[-4:]}"
 
 
 def flash_nrf_both_cores(

--- a/dotbot/tests/test_controller.py
+++ b/dotbot/tests/test_controller.py
@@ -194,7 +194,6 @@ async def test_controller_get_dotbots_query(query, length, controller):
     assert len(dotbots) == length
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_controller_sailbot_simulator():
     """Check controller called for sailbot simulator."""
 
@@ -211,11 +210,9 @@ def test_controller_sailbot_simulator():
         except asyncio.TimeoutError:
             pass
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(start_simulator())
+    asyncio.run(start_simulator())
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_controller_dotbot_simulator():
     """Check controller called for dotbot simulator."""
 
@@ -232,8 +229,7 @@ def test_controller_dotbot_simulator():
         except asyncio.TimeoutError:
             pass
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(start_simulator())
+    asyncio.run(start_simulator())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Improvements to `dotbot testbed provision flash`:

- **Fix `net_id` readback** — `read_net_id` was reading from `0x0103F804`, which is the `has_net_id` flag (always `1`) since the swarmit config struct grew that field at offset 4 and pushed the real `net_id` to offset 8. The hex written to flash was always correct; only the post-flash readback was lying. Now reads both fields and returns `"unprovisioned"` if `has_net_id != 1` (e.g. fresh chip falling back to `SWARMIT_DEFAULT_NET_ID = 0xA000`).
- **Add reset-button notice** — flash sometimes leaves the robot in a state where it doesn't join the network until the RESET button is pressed. Tried inverting the per-coprocessor reset order and switching to `--pinreset`; neither fixed it (suggests the underlying issue is in the SwarmIT bootloader's boot-mode decision, not the flashing tool). For now, print a yellow `[NOTE]` after the readback telling the operator to press reset if needed.

Also includes a small unrelated test-suite fix (`dotbot/tests/test_controller`: switch the two simulator tests to `asyncio.run()` so they survive newer `pytest-asyncio` cleanup behavior — without this commit, CI on the entire branch goes red).

Closes #252.

## Test plan

- [x] `dotbot testbed provision flash -d dotbot-v3 -f local -n 1234 -s 77` → reports `[INFO] net_id: 1234` (verified on real hardware).
- [x] Reset-button notice prints at end of flash.
- [x] `dotbot testbed provision read-config -s 77` on a freshly-erased chip → reports `unprovisioned`.