### PR TITLE
dotbot/adapter: dispatch frames by mari next_proto

### DIFF
--- a/dotbot/adapter.py
+++ b/dotbot/adapter.py
@@ -15,6 +15,7 @@ from dotbot_utils.serial_interface import SerialInterface
 from marilib.communication_adapter import MQTTAdapter as MarilibMQTTAdapter
 from marilib.communication_adapter import SerialAdapter as MarilibSerialAdapter
 from marilib.mari_protocol import Frame as MariFrame
+from marilib.mari_protocol import NextProto
 from marilib.marilib_cloud import MarilibCloud
 from marilib.marilib_edge import MarilibEdge
 from marilib.model import EdgeEvent, MariNode
@@ -115,6 +116,8 @@ class MarilibEdgeAdapter(GatewayAdapterBase):
             elif event == EdgeEvent.NODE_LEFT:
                 LOGGER.debug(f"Node left: {event_data.address:016x}")
             elif event == EdgeEvent.NODE_DATA:
+                if event_data.header.next_proto != NextProto.DOTBOT_APP:
+                    return
                 try:
                     packet = Packet.from_bytes(event_data.payload)
                 except (ValueError, ProtocolPayloadParserException) as exc:
@@ -143,6 +146,7 @@ class MarilibEdgeAdapter(GatewayAdapterBase):
         self.mari.send_frame(
             dst=destination,
             payload=Packet.from_payload(payload).to_bytes(),
+            next_proto=NextProto.DOTBOT_APP,
         )
 
 
@@ -172,6 +176,8 @@ class MarilibCloudAdapter(GatewayAdapterBase):
             elif event == EdgeEvent.NODE_LEFT:
                 LOGGER.debug(f"Node left: {event_data.address:016x}")
             elif event == EdgeEvent.NODE_DATA:
+                if event_data.header.next_proto != NextProto.DOTBOT_APP:
+                    return
                 try:
                     packet = Packet.from_bytes(event_data.payload)
                 except (ValueError, ProtocolPayloadParserException) as exc:
@@ -204,6 +210,7 @@ class MarilibCloudAdapter(GatewayAdapterBase):
         self.mari.send_frame(
             dst=destination,
             payload=Packet.from_payload(payload).to_bytes(),
+            next_proto=NextProto.DOTBOT_APP,
         )
 
 

--- a/dotbot/tests/test_adapter.py
+++ b/dotbot/tests/test_adapter.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 from dotbot_utils.hdlc import hdlc_encode
 from dotbot_utils.protocol import Frame, Header, Packet
+from marilib.mari_protocol import NextProto
 
 from dotbot.adapter import (
     DotBotSimulatorAdapter,
@@ -80,7 +81,9 @@ async def test_marilib_edge_adapter(_):
 
         adapter.send_payload(frame.header.destination, payload)
         adapter.mari.send_frame.assert_called_once_with(
-            dst=frame.header.destination, payload=frame.packet.to_bytes()
+            dst=frame.header.destination,
+            payload=frame.packet.to_bytes(),
+            next_proto=NextProto.DOTBOT_APP,
         )
         adapter.close()
         adapter.mari.close.assert_called_once()
@@ -115,7 +118,9 @@ async def test_marilib_cloud_adapter(_):
 
         adapter.send_payload(frame.header.destination, payload)
         adapter.mari.send_frame.assert_called_once_with(
-            dst=frame.header.destination, payload=frame.packet.to_bytes()
+            dst=frame.header.destination,
+            payload=frame.packet.to_bytes(),
+            next_proto=NextProto.DOTBOT_APP,
         )
         adapter.close()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "uvicorn        >= 0.32.0",
     "websockets     >= 13.1.0",
     "gmqtt          >= 0.7.0",
-    "marilib-pkg    >= 0.8.0",
+    "marilib-pkg    >= 0.9.0rc2",
     "pydotbot-utils >= 0.3.0",
     "toml           >= 0.10.2",
 ]


### PR DESCRIPTION
The marilib adapter decided payload type by sniffing the first payload byte of
every NODE_DATA frame. Now that mari's frame header carries an explicit
`next_proto` field (mari#154), PyDotBot's edge/cloud adapters dispatch on it:
they accept only frames labeled `DOTBOT_APP` and ignore the rest, and label
outbound host->robot traffic `DOTBOT_APP` on send. Each control plane owns its
own namespace instead of every consumer try-parsing the same bytes.

The gate is strict — frames whose `next_proto` isn't `DOTBOT_APP` are dropped
before parsing. Devices must run firmware that labels `next_proto` (post-#139)
before this is deployed; older firmware sends the unclassified default and would
be dropped. Reflash the fleet first.

Depends on `marilib-pkg 0.9.0rc2`, where labeling is the `send_frame(...,
next_proto=...)` keyword argument (mari#155); the pyproject bump is included
here. Validated with tox (tests + check) against the published rc. Hardware-in-the-loop validated.