### PR TITLE
dotbot/cli: real fw build + dotbot make + rename testbed to swarm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Python control plane for DotBots. Serial / cloud / edge adapters talk to a DotBot gateway (often via Mari → marilib); a FastAPI REST + WebSocket server exposes state; a React web UI provides joystick/map/lighthouse-position visualization. Ships a unified `dotbot` CLI (`dotbot controller`, `dotbot testbed`, `dotbot calibrate`, `dotbot demo`, `dotbot keyboard`, `dotbot joystick`, ...) plus DotBot/SailBot simulators. Legacy entry points `dotbot-controller` / `dotbot-keyboard` / `dotbot-joystick` are kept as backwards-compat aliases for one deprecation cycle.
+Python control plane for DotBots. Serial / cloud / edge adapters talk to a DotBot gateway (often via Mari → marilib); a FastAPI REST + WebSocket server exposes state; a React web UI provides joystick/map/lighthouse-position visualization. Ships a unified `dotbot` CLI (`dotbot controller`, `dotbot swarm`, `dotbot calibrate-lh2`, `dotbot fw`, `dotbot demo`, `dotbot keyboard`, `dotbot joystick`, ...) plus DotBot/SailBot simulators. Legacy entry points `dotbot-controller` / `dotbot-keyboard` / `dotbot-joystick` are kept as backwards-compat aliases for one deprecation cycle, as is the `dotbot testbed` subcommand (renamed to `dotbot swarm`).
 
 This is the most active repo in the ecosystem (187 commits in last 90 days as of 2026-05-05).
 
@@ -26,8 +26,9 @@ This is the most active repo in the ecosystem (187 commits in last 90 days as of
 pip install pydotbot                         # or `pip install -e .`
 dotbot --help               # unified dispatcher
 dotbot controller --help    # start the controller
-dotbot testbed --help       # testbed ops (optional: pip install pydotbot[testbed])
-dotbot calibrate --help     # LH2 calibration (optional: pip install pydotbot[calibrate])
+dotbot swarm --help         # swarm orchestration (optional: pip install pydotbot[swarm])
+dotbot calibrate-lh2 --help # LH2 calibration (optional: pip install pydotbot[calibrate])
+dotbot fw --help            # bare firmware build/clean/targets/artifacts
 dotbot demo --list          # built-in research demos
 
 # Tests / lint / build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Python control plane for DotBots. Serial / cloud / edge adapters talk to a DotBot gateway (often via Mari → marilib); a FastAPI REST + WebSocket server exposes state; a React web UI provides joystick/map/lighthouse-position visualization. Ships a unified `dotbot` CLI (`dotbot controller`, `dotbot swarm`, `dotbot calibrate-lh2`, `dotbot fw`, `dotbot demo`, `dotbot keyboard`, `dotbot joystick`, ...) plus DotBot/SailBot simulators. Legacy entry points `dotbot-controller` / `dotbot-keyboard` / `dotbot-joystick` are kept as backwards-compat aliases for one deprecation cycle, as is the `dotbot testbed` subcommand (renamed to `dotbot swarm`).
+Python control plane for DotBots. Serial / cloud / edge adapters talk to a DotBot gateway (often via Mari → marilib); a FastAPI REST + WebSocket server exposes state; a React web UI provides joystick/map/lighthouse-position visualization. Ships a unified `dotbot` CLI (`dotbot controller`, `dotbot swarm`, `dotbot calibrate-lh2`, `dotbot fw`, `dotbot make`, `dotbot demo`, `dotbot keyboard`, `dotbot joystick`, ...) plus DotBot/SailBot simulators. Legacy entry points `dotbot-controller` / `dotbot-keyboard` / `dotbot-joystick` are kept as backwards-compat aliases for one deprecation cycle.
 
 This is the most active repo in the ecosystem (187 commits in last 90 days as of 2026-05-05).
 

--- a/dotbot/cli/_fw_helpers.py
+++ b/dotbot/cli/_fw_helpers.py
@@ -304,23 +304,33 @@ def run_make(
 
 
 def artifact_path(target: str, project: str, config: str) -> Path:
-    """Return where the Makefile writes the artifact for (target, project, config).
+    """Return where SES writes the artifact for (target, project, config).
 
-    Mirrors `ARTIFACT_BASE` in DotBot-firmware/Makefile. Used so the CLI
-    can tell the user where to find the output, and for `dotbot fw
-    artifacts --print-path`.
+    SES uses its internal `$(BuildTarget)` macro for the Output directory
+    and the suffix on the file name. In both `dotbot-v3.emProject` and
+    `sandbox-dotbot-v3.emProject` that macro is hardcoded to the board
+    name (e.g. `dotbot-v3`) — the `sandbox-` prefix only affects which
+    apps/ directory SES uses, not the Output path. So the on-disk path
+    is `apps[-sandbox]/<app>/Output/<board>/<config>/Exe/<app>-<board>.<ext>`.
+
+    Note: DotBot-firmware's Makefile `ARTIFACT_BASE` formula uses the
+    Make-level `BUILD_TARGET` (which DOES include the `sandbox-` prefix)
+    and so disagrees with SES's actual output path for sandbox targets.
+    The CLI tracks the real on-disk location, not the (buggy) Makefile
+    expectation.
     """
     is_sandbox = target.startswith("sandbox-")
     apps_dir = "apps-sandbox" if is_sandbox else "apps"
     ext = "bin" if is_sandbox else "hex"
+    board = target[len("sandbox-") :] if is_sandbox else target
     repo = resolve_firmware_repo()
     return (
         repo
         / apps_dir
         / project
         / "Output"
-        / target
+        / board
         / config
         / "Exe"
-        / f"{project}-{target}.{ext}"
+        / f"{project}-{board}.{ext}"
     )

--- a/dotbot/cli/_fw_helpers.py
+++ b/dotbot/cli/_fw_helpers.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared helpers for `dotbot fw` (bare) and `dotbot swarm fw` (sandbox).
+
+Both subcommands shell out to the same `repos/DotBot-firmware/Makefile`,
+which discriminates bare vs sandbox by `BUILD_TARGET` prefix
+(`sandbox-*` routes to `apps-sandbox/`, everything else to `apps/`).
+The wrappers in `dotbot/cli/fw.py` (bare) and `dotbot/cli/_sandbox_fw.py`
+(sandbox) reuse the helpers here so target validation, SEGGER_DIR
+resolution, and the make invocation contract stay in one place.
+"""
+
+import difflib
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+import click
+
+# Hardcoded macOS install location used by the dotbot-testbed workspace
+# (see workspace AGENTS.md "Firmware builds — local SES" convention).
+# On Linux/Windows the user must set SEGGER_DIR explicitly.
+SEGGER_MACOS_DEFAULT = "/Applications/SEGGER/SEGGER Embedded Studio 8.22a"
+
+# BUILD_TARGET values handled by DotBot-firmware's Makefile (bare path).
+# Mirrors the explicit branches in the Makefile; an unrecognized target
+# falls through to the catch-all `find apps/` rule which produces opaque
+# SES errors, so we validate up-front.
+BARE_TARGETS = frozenset(
+    {
+        "dotbot-v1",
+        "dotbot-v2",
+        "dotbot-v3",
+        "nrf52833dk",
+        "nrf52840dk",
+        "nrf5340dk-app",
+        "nrf5340dk-net",
+        "sailbot-v1",
+        "freebot-v1.0",
+        "lh2-mini-mote",
+        "xgo-v1",
+        "xgo-v2",
+    }
+)
+
+# BUILD_TARGET = "sandbox-" + BOARD for the sandbox path. Boards
+# supported by the SES `.emProject` files at the DotBot-firmware root.
+SANDBOX_BOARDS = frozenset({"dotbot-v2", "dotbot-v3", "nrf5340dk"})
+
+# Valid `BUILD_CONFIG` values.
+CONFIGS = ("Debug", "Release")
+DEFAULT_CONFIG = "Release"
+DEFAULT_BARE_TARGET = "dotbot-v3"
+DEFAULT_SANDBOX_BOARD = "dotbot-v3"
+
+
+def resolve_segger_dir() -> Path:
+    """SEGGER_DIR env > macOS default > error with install hint."""
+    env = os.environ.get("SEGGER_DIR")
+    if env:
+        return Path(env)
+    if sys.platform == "darwin":
+        candidate = Path(SEGGER_MACOS_DEFAULT)
+        if (candidate / "bin" / "emBuild").is_file():
+            return candidate
+    raise click.ClickException(
+        "SEGGER_DIR is not set. Export it pointing at your SEGGER Embedded "
+        "Studio install root, e.g.\n"
+        f'  export SEGGER_DIR="{SEGGER_MACOS_DEFAULT}"'
+    )
+
+
+def resolve_firmware_repo() -> Path:
+    """Locate `repos/DotBot-firmware/Makefile` for the make invocation.
+
+    Walks up from CWD looking for a `repos/DotBot-firmware/Makefile`
+    sibling — works when run from anywhere inside the workspace.
+    Falls back to the `DOTBOT_FIRMWARE_REPO` env var.
+    """
+    env = os.environ.get("DOTBOT_FIRMWARE_REPO")
+    if env:
+        candidate = Path(env)
+        if (candidate / "Makefile").is_file():
+            return candidate
+        raise click.ClickException(
+            f"DOTBOT_FIRMWARE_REPO={env!r} does not contain a Makefile."
+        )
+    cwd = Path.cwd().resolve()
+    for parent in (cwd, *cwd.parents):
+        candidate = parent / "repos" / "DotBot-firmware"
+        if (candidate / "Makefile").is_file():
+            return candidate
+    raise click.ClickException(
+        "Could not locate `repos/DotBot-firmware`. Run this command from "
+        "inside the dotbot-testbed workspace, or set DOTBOT_FIRMWARE_REPO "
+        "to the path of your DotBot-firmware clone."
+    )
+
+
+def suggest_close_match(name: str, candidates: Iterable[str]) -> str:
+    """One-shot 'did you mean X?' suggestion, or empty string if none close."""
+    close = difflib.get_close_matches(name, list(candidates), n=1, cutoff=0.6)
+    return f" Did you mean {close[0]!r}?" if close else ""
+
+
+def validate_bare_target(target: str) -> None:
+    if target.startswith("sandbox-"):
+        raise click.ClickException(
+            f"{target!r} is a sandbox target. Use "
+            f"`dotbot swarm fw build {target[len('sandbox-'):]}` instead."
+        )
+    if target not in BARE_TARGETS:
+        hint = suggest_close_match(target, BARE_TARGETS)
+        raise click.ClickException(
+            f"Unknown bare target {target!r}.{hint}\n"
+            f"Run `dotbot fw targets` to list valid bare targets."
+        )
+
+
+def validate_sandbox_board(board: str) -> None:
+    if board.startswith("sandbox-"):
+        raise click.ClickException(
+            f"Drop the `sandbox-` prefix — pass just the board name: "
+            f"{board[len('sandbox-'):]!r}."
+        )
+    if board not in SANDBOX_BOARDS:
+        hint = suggest_close_match(board, SANDBOX_BOARDS)
+        raise click.ClickException(
+            f"Unknown sandbox board {board!r}.{hint}\n"
+            f"Run `dotbot swarm fw targets` to list valid sandbox boards."
+        )
+
+
+def _make_env(segger_dir: Path) -> dict:
+    env = dict(os.environ)
+    env["SEGGER_DIR"] = str(segger_dir)
+    return env
+
+
+def list_projects(target: str) -> list[str]:
+    """Return the post-filter project list for `target` via `make list-projects`."""
+    repo = resolve_firmware_repo()
+    segger = resolve_segger_dir()
+    result = subprocess.run(
+        ["make", "-s", "list-projects", f"BUILD_TARGET={target}"],
+        cwd=repo,
+        env=_make_env(segger),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise click.ClickException(
+            f"`make list-projects BUILD_TARGET={target}` failed:\n{result.stderr}"
+        )
+    # The Makefile recipe prints an ANSI-styled header line we want to skip;
+    # take only lines that look like bare project identifiers.
+    return [
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.strip()
+        and not line.strip().startswith(("\x1b", "\\e["))
+        and "Available projects" not in line
+    ]
+
+
+def run_make(
+    target: str,
+    config: str,
+    project: Optional[str] = None,
+    *,
+    rebuild: bool = False,
+    quiet: bool = True,
+    make_targets: Optional[list[str]] = None,
+) -> None:
+    """Invoke `make BUILD_TARGET=... BUILD_CONFIG=... [project|make_target]`.
+
+    rebuild=False asks the Makefile to use `-build` (incremental, fast);
+    rebuild=True restores the prior `-rebuild` behavior. Requires the
+    `BUILD_MODE` knob added in DotBot-firmware Makefile (commit
+    "makefile: parameterize emBuild -rebuild via BUILD_MODE knob").
+
+    quiet=True passes `QUIET=1` so the Makefile suppresses SES's
+    `-verbose -echo` flood; the per-project "Building project X" /
+    "Done" banners still come through.
+
+    If `make_targets` is given, those are the make-level targets passed
+    on the command line (e.g. `["clean"]`, `["artifacts"]`). Otherwise
+    `project` is appended (or nothing, which means default `all` →
+    every project for the BUILD_TARGET).
+    """
+    repo = resolve_firmware_repo()
+    segger = resolve_segger_dir()
+    embuild = segger / "bin" / "emBuild"
+    if not embuild.is_file():
+        raise click.ClickException(
+            f"emBuild not found at {embuild}. Check that SEGGER_DIR points "
+            f"at a real SES install."
+        )
+    cmd = ["make", f"BUILD_TARGET={target}", f"BUILD_CONFIG={config}"]
+    if quiet:
+        cmd.append("QUIET=1")
+    cmd.append(f"BUILD_MODE={'-rebuild' if rebuild else '-build'}")
+    if make_targets:
+        cmd.extend(make_targets)
+    elif project:
+        cmd.append(project)
+    # Print the command verbatim so the user can copy/paste to reproduce
+    # outside the CLI.
+    click.echo(f"$ {' '.join(cmd)}", err=True)
+    rc = subprocess.call(cmd, cwd=repo, env=_make_env(segger))
+    if rc != 0:
+        raise click.ClickException(f"`make` exited {rc}.")
+
+
+def artifact_path(target: str, project: str, config: str) -> Path:
+    """Return where the Makefile writes the artifact for (target, project, config).
+
+    Mirrors `ARTIFACT_BASE` in DotBot-firmware/Makefile. Used so the CLI
+    can tell the user where to find the output, and for `dotbot fw
+    artifacts --print-path`.
+    """
+    is_sandbox = target.startswith("sandbox-")
+    apps_dir = "apps-sandbox" if is_sandbox else "apps"
+    ext = "bin" if is_sandbox else "hex"
+    repo = resolve_firmware_repo()
+    return (
+        repo
+        / apps_dir
+        / project
+        / "Output"
+        / target
+        / config
+        / "Exe"
+        / f"{project}-{target}.{ext}"
+    )

--- a/dotbot/cli/_fw_helpers.py
+++ b/dotbot/cli/_fw_helpers.py
@@ -15,6 +15,7 @@ import difflib
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -175,7 +176,7 @@ def run_make(
     rebuild: bool = False,
     quiet: bool = True,
     make_targets: Optional[list[str]] = None,
-) -> None:
+) -> float:
     """Invoke `make BUILD_TARGET=... BUILD_CONFIG=... [project|make_target]`.
 
     rebuild=False asks the Makefile to use `-build` (incremental, fast);
@@ -185,12 +186,17 @@ def run_make(
 
     quiet=True passes `QUIET=1` so the Makefile suppresses SES's
     `-verbose -echo` flood; the per-project "Building project X" /
-    "Done" banners still come through.
+    "Done" banners still come through. quiet=False also echoes the full
+    make command line to stderr so the user has a copy-pasteable line
+    to reproduce outside the CLI.
 
     If `make_targets` is given, those are the make-level targets passed
     on the command line (e.g. `["clean"]`, `["artifacts"]`). Otherwise
     `project` is appended (or nothing, which means default `all` →
     every project for the BUILD_TARGET).
+
+    Returns elapsed wall-clock seconds. Raises `ClickException` on
+    non-zero exit so callers can short-circuit.
     """
     repo = resolve_firmware_repo()
     segger = resolve_segger_dir()
@@ -208,12 +214,16 @@ def run_make(
         cmd.extend(make_targets)
     elif project:
         cmd.append(project)
-    # Print the command verbatim so the user can copy/paste to reproduce
-    # outside the CLI.
-    click.echo(f"$ {' '.join(cmd)}", err=True)
+    if not quiet:
+        # Verbose mode: print the make command so the user can copy/paste
+        # it to reproduce outside the CLI.
+        click.echo(f"$ {' '.join(cmd)}", err=True)
+    t0 = time.perf_counter()
     rc = subprocess.call(cmd, cwd=repo, env=_make_env(segger))
+    elapsed = time.perf_counter() - t0
     if rc != 0:
-        raise click.ClickException(f"`make` exited {rc}.")
+        raise click.ClickException(f"`make` exited {rc} after {elapsed:.1f}s.")
+    return elapsed
 
 
 def artifact_path(target: str, project: str, config: str) -> Path:

--- a/dotbot/cli/_fw_helpers.py
+++ b/dotbot/cli/_fw_helpers.py
@@ -256,8 +256,10 @@ def run_make(
 ) -> float:
     """Invoke `make BUILD_TARGET=... BUILD_CONFIG=... [project|make_target]`.
 
-    rebuild=False asks the Makefile to use `-build` (incremental, fast);
-    rebuild=True restores the prior `-rebuild` behavior. Requires the
+    rebuild=False passes an empty `BUILD_MODE=` to make so the
+    `emBuild` recipe runs with no action flag — emBuild defaults to
+    incremental builds in that case. rebuild=True passes
+    `BUILD_MODE=-rebuild` to force full rebuilds. Requires the
     `BUILD_MODE` knob added in DotBot-firmware Makefile (commit
     "makefile: parameterize emBuild -rebuild via BUILD_MODE knob").
 
@@ -286,7 +288,7 @@ def run_make(
     cmd = ["make", f"BUILD_TARGET={target}", f"BUILD_CONFIG={config}"]
     if quiet:
         cmd.append("QUIET=1")
-    cmd.append(f"BUILD_MODE={'-rebuild' if rebuild else '-build'}")
+    cmd.append(f"BUILD_MODE={'-rebuild' if rebuild else ''}")
     if make_targets:
         cmd.extend(make_targets)
     elif project:

--- a/dotbot/cli/_fw_helpers.py
+++ b/dotbot/cli/_fw_helpers.py
@@ -309,30 +309,23 @@ def artifact_path(target: str, project: str, config: str) -> Path:
     """Return where SES writes the artifact for (target, project, config).
 
     SES uses its internal `$(BuildTarget)` macro for the Output directory
-    and the suffix on the file name. In both `dotbot-v3.emProject` and
-    `sandbox-dotbot-v3.emProject` that macro is hardcoded to the board
-    name (e.g. `dotbot-v3`) — the `sandbox-` prefix only affects which
-    apps/ directory SES uses, not the Output path. So the on-disk path
-    is `apps[-sandbox]/<app>/Output/<board>/<config>/Exe/<app>-<board>.<ext>`.
-
-    Note: DotBot-firmware's Makefile `ARTIFACT_BASE` formula uses the
-    Make-level `BUILD_TARGET` (which DOES include the `sandbox-` prefix)
-    and so disagrees with SES's actual output path for sandbox targets.
-    The CLI tracks the real on-disk location, not the (buggy) Makefile
-    expectation.
+    and the suffix on the file name. The `.emProject` solution files set
+    that macro to match the make-level `BUILD_TARGET` exactly (bare
+    `dotbot-v3` → `BuildTarget=dotbot-v3`, sandbox `sandbox-dotbot-v3` →
+    `BuildTarget=sandbox-dotbot-v3`), so the on-disk path mirrors what
+    the Makefile's `ARTIFACT_BASE` formula expects.
     """
     is_sandbox = target.startswith("sandbox-")
     apps_dir = "apps-sandbox" if is_sandbox else "apps"
     ext = "bin" if is_sandbox else "hex"
-    board = target[len("sandbox-") :] if is_sandbox else target
     repo = resolve_firmware_repo()
     return (
         repo
         / apps_dir
         / project
         / "Output"
-        / board
+        / target
         / config
         / "Exe"
-        / f"{project}-{board}.{ext}"
+        / f"{project}-{target}.{ext}"
     )

--- a/dotbot/cli/_fw_helpers.py
+++ b/dotbot/cli/_fw_helpers.py
@@ -3,15 +3,35 @@
 
 """Shared helpers for `dotbot fw` (bare) and `dotbot swarm fw` (sandbox).
 
-Both subcommands shell out to the same `repos/DotBot-firmware/Makefile`,
+Both subcommands shell out to the same `DotBot-firmware` Makefile,
 which discriminates bare vs sandbox by `BUILD_TARGET` prefix
 (`sandbox-*` routes to `apps-sandbox/`, everything else to `apps/`).
 The wrappers in `dotbot/cli/fw.py` (bare) and `dotbot/cli/_sandbox_fw.py`
 (sandbox) reuse the helpers here so target validation, SEGGER_DIR
 resolution, and the make invocation contract stay in one place.
+
+## Configuration
+
+`SEGGER_DIR` and the path to the DotBot-firmware checkout can be set
+in `~/.dotbot/config.toml` so they don't need to be passed via env
+on every shell:
+
+```toml
+[fw]
+segger_dir = "/Applications/SEGGER/SEGGER Embedded Studio 8.30"
+firmware_repo = "/Users/me/Developer/dotbot-testbed/repos/DotBot-firmware"
+```
+
+Resolution order (first match wins):
+- `SEGGER_DIR` env var ↦ `[fw].segger_dir` in config ↦ glob
+  `/Applications/SEGGER/SEGGER Embedded Studio*` on macOS (latest
+  sort-order pick).
+- `DOTBOT_FIRMWARE_REPO` env var ↦ `[fw].firmware_repo` in config ↦
+  walk up from CWD looking for `repos/DotBot-firmware/Makefile`.
 """
 
 import difflib
+import glob
 import os
 import subprocess
 import sys
@@ -20,11 +40,18 @@ from pathlib import Path
 from typing import Iterable, Optional
 
 import click
+import toml
 
-# Hardcoded macOS install location used by the dotbot-testbed workspace
-# (see workspace AGENTS.md "Firmware builds — local SES" convention).
-# On Linux/Windows the user must set SEGGER_DIR explicitly.
-SEGGER_MACOS_DEFAULT = "/Applications/SEGGER/SEGGER Embedded Studio 8.22a"
+# Glob used to discover SES installs on macOS. Picks the lexicographically
+# largest match (e.g. "Studio 8.30" beats "Studio 8.22a"), which is good
+# enough as a fallback when the user hasn't set SEGGER_DIR or written
+# `[fw].segger_dir` in `~/.dotbot/config.toml`.
+_SEGGER_MACOS_GLOB = "/Applications/SEGGER/SEGGER Embedded Studio*"
+
+# Per-user persistent config — shares the `~/.dotbot/` directory the
+# controller / calibration already use (see dotbot/controller.py's
+# CALIBRATION_PATH).
+_CONFIG_PATH = Path.home() / ".dotbot" / "config.toml"
 
 # BUILD_TARGET values handled by DotBot-firmware's Makefile (bare path).
 # Mirrors the explicit branches in the Makefile; an unrecognized target
@@ -58,29 +85,67 @@ DEFAULT_BARE_TARGET = "dotbot-v3"
 DEFAULT_SANDBOX_BOARD = "dotbot-v3"
 
 
+def load_config() -> dict:
+    """Read `~/.dotbot/config.toml`. Empty dict if missing.
+
+    Raises ClickException with the file path if the TOML is malformed,
+    so the user knows where to fix.
+    """
+    if not _CONFIG_PATH.is_file():
+        return {}
+    try:
+        return toml.load(_CONFIG_PATH)
+    except toml.TomlDecodeError as exc:
+        raise click.ClickException(
+            f"Failed to parse {_CONFIG_PATH}: {exc}"
+        ) from exc
+
+
+def _config_fw_value(key: str) -> Optional[str]:
+    """Read `[fw].<key>` from `~/.dotbot/config.toml`, or None."""
+    fw_section = load_config().get("fw") or {}
+    val = fw_section.get(key)
+    return str(val) if val else None
+
+
+def _glob_macos_segger() -> Optional[Path]:
+    """Pick the lexicographically-latest SES install matching the glob.
+
+    Returns None if no match has a usable `bin/emBuild`. The sort order
+    favours newer versions (e.g. `8.30` > `8.22a`) for typical SES
+    version strings.
+    """
+    if sys.platform != "darwin":
+        return None
+    matches = sorted(glob.glob(_SEGGER_MACOS_GLOB))
+    for match in reversed(matches):
+        candidate = Path(match)
+        if (candidate / "bin" / "emBuild").is_file():
+            return candidate
+    return None
+
+
 def resolve_segger_dir() -> Path:
-    """SEGGER_DIR env > macOS default > error with install hint."""
+    """SEGGER_DIR env → config → macOS glob → error."""
     env = os.environ.get("SEGGER_DIR")
     if env:
         return Path(env)
-    if sys.platform == "darwin":
-        candidate = Path(SEGGER_MACOS_DEFAULT)
-        if (candidate / "bin" / "emBuild").is_file():
-            return candidate
+    cfg = _config_fw_value("segger_dir")
+    if cfg:
+        return Path(cfg)
+    macos = _glob_macos_segger()
+    if macos:
+        return macos
     raise click.ClickException(
-        "SEGGER_DIR is not set. Export it pointing at your SEGGER Embedded "
-        "Studio install root, e.g.\n"
-        f'  export SEGGER_DIR="{SEGGER_MACOS_DEFAULT}"'
+        "SEGGER_DIR is not set and no SEGGER install was found.\n"
+        "Either export SEGGER_DIR, or add to ~/.dotbot/config.toml:\n"
+        "  [fw]\n"
+        '  segger_dir = "/path/to/SEGGER Embedded Studio X.YY"'
     )
 
 
 def resolve_firmware_repo() -> Path:
-    """Locate `repos/DotBot-firmware/Makefile` for the make invocation.
-
-    Walks up from CWD looking for a `repos/DotBot-firmware/Makefile`
-    sibling — works when run from anywhere inside the workspace.
-    Falls back to the `DOTBOT_FIRMWARE_REPO` env var.
-    """
+    """DOTBOT_FIRMWARE_REPO env → config → workspace walk-up → error."""
     env = os.environ.get("DOTBOT_FIRMWARE_REPO")
     if env:
         candidate = Path(env)
@@ -89,15 +154,27 @@ def resolve_firmware_repo() -> Path:
         raise click.ClickException(
             f"DOTBOT_FIRMWARE_REPO={env!r} does not contain a Makefile."
         )
+    cfg = _config_fw_value("firmware_repo")
+    if cfg:
+        candidate = Path(cfg)
+        if (candidate / "Makefile").is_file():
+            return candidate
+        raise click.ClickException(
+            f"[fw].firmware_repo={cfg!r} in {_CONFIG_PATH} does not contain "
+            f"a Makefile."
+        )
     cwd = Path.cwd().resolve()
     for parent in (cwd, *cwd.parents):
         candidate = parent / "repos" / "DotBot-firmware"
         if (candidate / "Makefile").is_file():
             return candidate
     raise click.ClickException(
-        "Could not locate `repos/DotBot-firmware`. Run this command from "
-        "inside the dotbot-testbed workspace, or set DOTBOT_FIRMWARE_REPO "
-        "to the path of your DotBot-firmware clone."
+        "Could not locate DotBot-firmware.\n"
+        "Either run from inside a workspace that has "
+        "`repos/DotBot-firmware`, export DOTBOT_FIRMWARE_REPO, or add to "
+        "~/.dotbot/config.toml:\n"
+        "  [fw]\n"
+        '  firmware_repo = "/path/to/DotBot-firmware"'
     )
 
 

--- a/dotbot/cli/_fw_helpers.py
+++ b/dotbot/cli/_fw_helpers.py
@@ -96,9 +96,7 @@ def load_config() -> dict:
     try:
         return toml.load(_CONFIG_PATH)
     except toml.TomlDecodeError as exc:
-        raise click.ClickException(
-            f"Failed to parse {_CONFIG_PATH}: {exc}"
-        ) from exc
+        raise click.ClickException(f"Failed to parse {_CONFIG_PATH}: {exc}") from exc
 
 
 def _config_fw_value(key: str) -> Optional[str]:

--- a/dotbot/cli/_sandbox_fw.py
+++ b/dotbot/cli/_sandbox_fw.py
@@ -91,7 +91,13 @@ def build(board, project, config, rebuild, verbose):
                 f"Sandbox app {project!r} is not available for board "
                 f"{board!r}.\nAvailable: {', '.join(valid)}"
             )
-    run_make(target, config, project, rebuild=rebuild, quiet=not verbose)
+    mode = "rebuild" if rebuild else "incremental"
+    what = project or "all sandbox apps"
+    click.echo(
+        f"Building {what} for {board} sandbox ({config}, {mode})...", err=True
+    )
+    elapsed = run_make(target, config, project, rebuild=rebuild, quiet=not verbose)
+    click.echo(f"✓ Built sandbox {board} in {elapsed:.1f}s", err=True)
     if project:
         out = artifact_path(target, project, config)
         if out.is_file():
@@ -110,7 +116,11 @@ def build(board, project, config, rebuild, verbose):
 def clean(board, config, verbose):
     """Clean SES build outputs for BOARD (per BUILD_CONFIG)."""
     validate_sandbox_board(board)
-    run_make(_board_to_target(board), config, make_targets=["clean"], quiet=not verbose)
+    click.echo(f"Cleaning {board} sandbox ({config})...", err=True)
+    elapsed = run_make(
+        _board_to_target(board), config, make_targets=["clean"], quiet=not verbose
+    )
+    click.echo(f"✓ Cleaned sandbox {board} in {elapsed:.1f}s", err=True)
 
 
 @cmd.command(name="targets")
@@ -148,4 +158,6 @@ def artifacts(board, project, config, print_path, verbose):
             )
         click.echo(str(artifact_path(target, project, config)))
         return
-    run_make(target, config, make_targets=["artifacts"], quiet=not verbose)
+    click.echo(f"Collecting artifacts for {board} sandbox ({config})...", err=True)
+    elapsed = run_make(target, config, make_targets=["artifacts"], quiet=not verbose)
+    click.echo(f"✓ Artifacts collected in {elapsed:.1f}s", err=True)

--- a/dotbot/cli/_sandbox_fw.py
+++ b/dotbot/cli/_sandbox_fw.py
@@ -194,13 +194,10 @@ def artifacts(target, project, config, out_dir, print_path, verbose):
     for app in apps_to_collect:
         src = artifact_path(build_target, app, config)
         if src.is_file():
-            # Prepend `sandbox-` so the file is distinguishable from any
-            # bare equivalent (e.g. `apps/dotbot/`'s `dotbot-dotbot-v3.hex`)
-            # when both flavors land in the same `./artifacts/` dir. Kept
-            # at the CLI-copy layer rather than as an upstream project
-            # rename — that would force `--app dotbot-sandbox` redundancy
-            # under the already-sandbox-implying `dotbot swarm fw` namespace.
-            dst = out / f"sandbox-{src.name}"
+            # SES's $(BuildTarget) macro now includes the `sandbox-` prefix,
+            # so the source filename is already distinct from any bare
+            # equivalent — no CLI-side mangling needed.
+            dst = out / src.name
             shutil.copy2(src, dst)
             copied.append(dst)
     click.echo(

--- a/dotbot/cli/_sandbox_fw.py
+++ b/dotbot/cli/_sandbox_fw.py
@@ -194,7 +194,13 @@ def artifacts(target, project, config, out_dir, print_path, verbose):
     for app in apps_to_collect:
         src = artifact_path(build_target, app, config)
         if src.is_file():
-            dst = out / src.name
+            # Prepend `sandbox-` so the file is distinguishable from any
+            # bare equivalent (e.g. `apps/dotbot/`'s `dotbot-dotbot-v3.hex`)
+            # when both flavors land in the same `./artifacts/` dir. Kept
+            # at the CLI-copy layer rather than as an upstream project
+            # rename — that would force `--app dotbot-sandbox` redundancy
+            # under the already-sandbox-implying `dotbot swarm fw` namespace.
+            dst = out / f"sandbox-{src.name}"
             shutil.copy2(src, dst)
             copied.append(dst)
     click.echo(

--- a/dotbot/cli/_sandbox_fw.py
+++ b/dotbot/cli/_sandbox_fw.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""`dotbot swarm fw` — TrustZone-sandbox firmware build/clean/targets/artifacts.
+
+Sandbox apps live under `repos/DotBot-firmware/apps-sandbox/` and run as
+non-secure user images inside the SwarmIT TrustZone bootloader; they are
+OTA-flashed via `dotbot swarm flash`. The Makefile uses `sandbox-<BOARD>`
+as the `BUILD_TARGET` to route into `apps-sandbox/` and emit `.bin`
+(what swarmit OTA flashes) instead of `.hex`. This subgroup hides the
+`sandbox-` prefix — the user types `dotbot swarm fw build dotbot-v3`
+and the CLI prepends it before invoking make.
+
+Mounted on the `dotbot swarm` group by `dotbot/cli/swarm.py`.
+"""
+
+import click
+
+from dotbot.cli._fw_helpers import (
+    CONFIGS,
+    DEFAULT_CONFIG,
+    DEFAULT_SANDBOX_BOARD,
+    SANDBOX_BOARDS,
+    artifact_path,
+    list_projects,
+    run_make,
+    validate_sandbox_board,
+)
+
+
+@click.group(
+    name="fw",
+    help=(
+        "Sandbox (TrustZone NS) firmware: build, clean, list boards, "
+        "collect artifacts. For bare firmware that talks directly to the "
+        "radio, see `dotbot fw`."
+    ),
+)
+def cmd():
+    pass
+
+
+def _board_to_target(board: str) -> str:
+    return f"sandbox-{board}"
+
+
+def _project_option(f):
+    return click.option(
+        "--app",
+        "project",
+        type=str,
+        default=None,
+        help=(
+            "Build a single sandbox app (e.g. `dotbot`, `motors`, `rgbled`). "
+            "Default: build every sandbox app for BOARD."
+        ),
+    )(f)
+
+
+@cmd.command()
+@click.argument("board", default=DEFAULT_SANDBOX_BOARD)
+@_project_option
+@click.option(
+    "--config",
+    type=click.Choice(CONFIGS),
+    default=DEFAULT_CONFIG,
+    show_default=True,
+)
+@click.option(
+    "--rebuild",
+    is_flag=True,
+    default=False,
+    help="Force full rebuild (pass `-rebuild` to emBuild). Default: incremental.",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="Show full SES `-verbose -echo` output.",
+)
+def build(board, project, config, rebuild, verbose):
+    """Build sandbox firmware for BOARD (default: dotbot-v3)."""
+    validate_sandbox_board(board)
+    target = _board_to_target(board)
+    if project:
+        valid = list_projects(target)
+        if project not in valid:
+            raise click.ClickException(
+                f"Sandbox app {project!r} is not available for board "
+                f"{board!r}.\nAvailable: {', '.join(valid)}"
+            )
+    run_make(target, config, project, rebuild=rebuild, quiet=not verbose)
+    if project:
+        out = artifact_path(target, project, config)
+        if out.is_file():
+            click.echo(str(out))
+
+
+@cmd.command()
+@click.argument("board", default=DEFAULT_SANDBOX_BOARD)
+@click.option(
+    "--config",
+    type=click.Choice(CONFIGS),
+    default=DEFAULT_CONFIG,
+    show_default=True,
+)
+@click.option("-v", "--verbose", is_flag=True, default=False)
+def clean(board, config, verbose):
+    """Clean SES build outputs for BOARD (per BUILD_CONFIG)."""
+    validate_sandbox_board(board)
+    run_make(_board_to_target(board), config, make_targets=["clean"], quiet=not verbose)
+
+
+@cmd.command(name="targets")
+def list_targets():
+    """List valid BOARDs for `dotbot swarm fw build` (one per line)."""
+    for b in sorted(SANDBOX_BOARDS):
+        click.echo(b)
+
+
+@cmd.command()
+@click.argument("board", default=DEFAULT_SANDBOX_BOARD)
+@_project_option
+@click.option(
+    "--config",
+    type=click.Choice(CONFIGS),
+    default=DEFAULT_CONFIG,
+    show_default=True,
+)
+@click.option(
+    "--print-path",
+    is_flag=True,
+    default=False,
+    help="Print where the artifact lives without building.",
+)
+@click.option("-v", "--verbose", is_flag=True, default=False)
+def artifacts(board, project, config, print_path, verbose):
+    """Build + collect canonical sandbox artifacts into `artifacts/`."""
+    validate_sandbox_board(board)
+    target = _board_to_target(board)
+    if print_path:
+        if not project:
+            raise click.ClickException(
+                "`--print-path` requires `--app NAME` — there is no canonical "
+                "artifact path without a specific project."
+            )
+        click.echo(str(artifact_path(target, project, config)))
+        return
+    run_make(target, config, make_targets=["artifacts"], quiet=not verbose)

--- a/dotbot/cli/_sandbox_fw.py
+++ b/dotbot/cli/_sandbox_fw.py
@@ -33,7 +33,8 @@ from dotbot.cli._fw_helpers import (
     help=(
         "Sandbox (TrustZone NS) firmware: build, clean, list boards, "
         "collect artifacts. For bare firmware that talks directly to the "
-        "radio, see `dotbot fw`."
+        "radio, see `dotbot fw`. Need a Makefile knob not covered by these "
+        "flags? Use `dotbot make --help`."
     ),
 )
 def cmd():

--- a/dotbot/cli/_sandbox_fw.py
+++ b/dotbot/cli/_sandbox_fw.py
@@ -114,9 +114,7 @@ def build(target, project, config, rebuild, verbose):
         )
     mode = "rebuild" if rebuild else "incremental"
     what = project or "all sandbox apps"
-    click.echo(
-        f"Building {what} for {target} sandbox ({config}, {mode})...", err=True
-    )
+    click.echo(f"Building {what} for {target} sandbox ({config}, {mode})...", err=True)
     elapsed = run_make(
         build_target, config, project, rebuild=rebuild, quiet=not verbose
     )
@@ -200,8 +198,6 @@ def artifacts(target, project, config, out_dir, print_path, verbose):
             dst = out / src.name
             shutil.copy2(src, dst)
             copied.append(dst)
-    click.echo(
-        f"✓ Collected {len(copied)} artifact(s) in {elapsed:.1f}s", err=True
-    )
+    click.echo(f"✓ Collected {len(copied)} artifact(s) in {elapsed:.1f}s", err=True)
     for p in copied:
         click.echo(str(p))

--- a/dotbot/cli/_sandbox_fw.py
+++ b/dotbot/cli/_sandbox_fw.py
@@ -16,6 +16,9 @@ This subgroup hides the `sandbox-` prefix from the user: typing
 Mounted on the `dotbot swarm` group by `dotbot/cli/swarm.py`.
 """
 
+import shutil
+from pathlib import Path
+
 import click
 
 from dotbot.cli._fw_helpers import (
@@ -25,7 +28,6 @@ from dotbot.cli._fw_helpers import (
     SANDBOX_BOARDS,
     artifact_path,
     list_projects,
-    resolve_firmware_repo,
     run_make,
     validate_sandbox_board,
 )
@@ -151,14 +153,22 @@ def list_targets():
 @_project_option
 @_config_option
 @click.option(
+    "--out",
+    "out_dir",
+    type=click.Path(file_okay=False, dir_okay=True),
+    default="./artifacts",
+    show_default=True,
+    help="Where to put the collected artifacts (resolved against your CWD).",
+)
+@click.option(
     "--print-path",
     is_flag=True,
     default=False,
     help="Print where the artifact lives without building.",
 )
 @click.option("-v", "--verbose", is_flag=True, default=False)
-def artifacts(target, project, config, print_path, verbose):
-    """Build + collect canonical sandbox artifacts into `artifacts/`."""
+def artifacts(target, project, config, out_dir, print_path, verbose):
+    """Build + collect sandbox artifacts into ./artifacts/ (default)."""
     validate_sandbox_board(target)
     build_target = f"sandbox-{target}"
     if print_path:
@@ -169,12 +179,26 @@ def artifacts(target, project, config, print_path, verbose):
             )
         click.echo(str(artifact_path(build_target, project, config)))
         return
-    click.echo(f"Collecting artifacts for {target} sandbox ({config})...", err=True)
-    elapsed = run_make(
-        build_target, config, make_targets=["artifacts"], quiet=not verbose
+    out = Path(out_dir).resolve()
+    click.echo(
+        f"Building + collecting artifacts for {target} sandbox ({config}) → "
+        f"{out}/...",
+        err=True,
     )
-    click.echo(f"✓ Artifacts collected in {elapsed:.1f}s", err=True)
-    artifacts_dir = resolve_firmware_repo() / "artifacts"
-    if artifacts_dir.is_dir():
-        for p in sorted(artifacts_dir.glob(f"*-{build_target}.bin")):
-            click.echo(str(p))
+    # Force a full rebuild — see `dotbot/cli/fw.py:artifacts` for why
+    # (sandbox and bare builds share the SES Output dir per board).
+    elapsed = run_make(build_target, config, project, rebuild=True, quiet=not verbose)
+    out.mkdir(parents=True, exist_ok=True)
+    apps_to_collect = [project] if project else list_projects(build_target)
+    copied = []
+    for app in apps_to_collect:
+        src = artifact_path(build_target, app, config)
+        if src.is_file():
+            dst = out / src.name
+            shutil.copy2(src, dst)
+            copied.append(dst)
+    click.echo(
+        f"✓ Collected {len(copied)} artifact(s) in {elapsed:.1f}s", err=True
+    )
+    for p in copied:
+        click.echo(str(p))

--- a/dotbot/cli/_sandbox_fw.py
+++ b/dotbot/cli/_sandbox_fw.py
@@ -4,12 +4,14 @@
 """`dotbot swarm fw` — TrustZone-sandbox firmware build/clean/targets/artifacts.
 
 Sandbox apps live under `repos/DotBot-firmware/apps-sandbox/` and run as
-non-secure user images inside the SwarmIT TrustZone bootloader; they are
-OTA-flashed via `dotbot swarm flash`. The Makefile uses `sandbox-<BOARD>`
-as the `BUILD_TARGET` to route into `apps-sandbox/` and emit `.bin`
-(what swarmit OTA flashes) instead of `.hex`. This subgroup hides the
-`sandbox-` prefix — the user types `dotbot swarm fw build dotbot-v3`
-and the CLI prepends it before invoking make.
+non-secure user images inside the SwarmIT TrustZone bootloader; they
+are OTA-flashed via `dotbot swarm flash`. The Makefile uses
+`sandbox-<board>` as its `BUILD_TARGET` to route into `apps-sandbox/`
+and emit `.bin` (what swarmit OTA flashes) instead of `.hex`.
+
+This subgroup hides the `sandbox-` prefix from the user: typing
+`dotbot swarm fw build --target dotbot-v3` invokes make with
+`BUILD_TARGET=sandbox-dotbot-v3`.
 
 Mounted on the `dotbot swarm` group by `dotbot/cli/swarm.py`.
 """
@@ -23,6 +25,7 @@ from dotbot.cli._fw_helpers import (
     SANDBOX_BOARDS,
     artifact_path,
     list_projects,
+    resolve_firmware_repo,
     run_make,
     validate_sandbox_board,
 )
@@ -41,32 +44,49 @@ def cmd():
     pass
 
 
-def _board_to_target(board: str) -> str:
-    return f"sandbox-{board}"
+def _target_option(f):
+    """Reusable `--target/-t` option — same flag name as `dotbot fw`."""
+    return click.option(
+        "--target",
+        "-t",
+        default=DEFAULT_SANDBOX_BOARD,
+        show_default=True,
+        help=(
+            "Board to build the sandbox firmware for (e.g. dotbot-v3, "
+            "nrf5340dk — without the `sandbox-` prefix; the CLI adds it). "
+            "See `dotbot swarm fw targets`."
+        ),
+    )(f)
 
 
 def _project_option(f):
     return click.option(
         "--app",
+        "-a",
         "project",
         type=str,
         default=None,
         help=(
             "Build a single sandbox app (e.g. `dotbot`, `motors`, `rgbled`). "
-            "Default: build every sandbox app for BOARD."
+            "Default: build every sandbox app for the target."
         ),
     )(f)
 
 
+def _config_option(f):
+    return click.option(
+        "--config",
+        "-c",
+        type=click.Choice(CONFIGS),
+        default=DEFAULT_CONFIG,
+        show_default=True,
+    )(f)
+
+
 @cmd.command()
-@click.argument("board", default=DEFAULT_SANDBOX_BOARD)
+@_target_option
 @_project_option
-@click.option(
-    "--config",
-    type=click.Choice(CONFIGS),
-    default=DEFAULT_CONFIG,
-    show_default=True,
-)
+@_config_option
 @click.option(
     "--rebuild",
     is_flag=True,
@@ -80,65 +100,56 @@ def _project_option(f):
     default=False,
     help="Show full SES `-verbose -echo` output.",
 )
-def build(board, project, config, rebuild, verbose):
-    """Build sandbox firmware for BOARD (default: dotbot-v3)."""
-    validate_sandbox_board(board)
-    target = _board_to_target(board)
-    if project:
-        valid = list_projects(target)
-        if project not in valid:
-            raise click.ClickException(
-                f"Sandbox app {project!r} is not available for board "
-                f"{board!r}.\nAvailable: {', '.join(valid)}"
-            )
+def build(target, project, config, rebuild, verbose):
+    """Build sandbox firmware (default target: dotbot-v3)."""
+    validate_sandbox_board(target)
+    build_target = f"sandbox-{target}"
+    apps_to_build = [project] if project else list_projects(build_target)
+    if project and project not in list_projects(build_target):
+        raise click.ClickException(
+            f"Sandbox app {project!r} is not available for target "
+            f"{target!r}.\nAvailable: {', '.join(list_projects(build_target))}"
+        )
     mode = "rebuild" if rebuild else "incremental"
     what = project or "all sandbox apps"
     click.echo(
-        f"Building {what} for {board} sandbox ({config}, {mode})...", err=True
+        f"Building {what} for {target} sandbox ({config}, {mode})...", err=True
     )
-    elapsed = run_make(target, config, project, rebuild=rebuild, quiet=not verbose)
-    click.echo(f"✓ Built sandbox {board} in {elapsed:.1f}s", err=True)
-    if project:
-        out = artifact_path(target, project, config)
+    elapsed = run_make(
+        build_target, config, project, rebuild=rebuild, quiet=not verbose
+    )
+    click.echo(f"✓ Built sandbox {target} in {elapsed:.1f}s", err=True)
+    for app in apps_to_build:
+        out = artifact_path(build_target, app, config)
         if out.is_file():
             click.echo(str(out))
 
 
 @cmd.command()
-@click.argument("board", default=DEFAULT_SANDBOX_BOARD)
-@click.option(
-    "--config",
-    type=click.Choice(CONFIGS),
-    default=DEFAULT_CONFIG,
-    show_default=True,
-)
+@_target_option
+@_config_option
 @click.option("-v", "--verbose", is_flag=True, default=False)
-def clean(board, config, verbose):
-    """Clean SES build outputs for BOARD (per BUILD_CONFIG)."""
-    validate_sandbox_board(board)
-    click.echo(f"Cleaning {board} sandbox ({config})...", err=True)
+def clean(target, config, verbose):
+    """Clean SES build outputs (default target: dotbot-v3)."""
+    validate_sandbox_board(target)
+    click.echo(f"Cleaning {target} sandbox ({config})...", err=True)
     elapsed = run_make(
-        _board_to_target(board), config, make_targets=["clean"], quiet=not verbose
+        f"sandbox-{target}", config, make_targets=["clean"], quiet=not verbose
     )
-    click.echo(f"✓ Cleaned sandbox {board} in {elapsed:.1f}s", err=True)
+    click.echo(f"✓ Cleaned sandbox {target} in {elapsed:.1f}s", err=True)
 
 
 @cmd.command(name="targets")
 def list_targets():
-    """List valid BOARDs for `dotbot swarm fw build` (one per line)."""
+    """List valid targets for `dotbot swarm fw build` (one per line)."""
     for b in sorted(SANDBOX_BOARDS):
         click.echo(b)
 
 
 @cmd.command()
-@click.argument("board", default=DEFAULT_SANDBOX_BOARD)
+@_target_option
 @_project_option
-@click.option(
-    "--config",
-    type=click.Choice(CONFIGS),
-    default=DEFAULT_CONFIG,
-    show_default=True,
-)
+@_config_option
 @click.option(
     "--print-path",
     is_flag=True,
@@ -146,18 +157,24 @@ def list_targets():
     help="Print where the artifact lives without building.",
 )
 @click.option("-v", "--verbose", is_flag=True, default=False)
-def artifacts(board, project, config, print_path, verbose):
+def artifacts(target, project, config, print_path, verbose):
     """Build + collect canonical sandbox artifacts into `artifacts/`."""
-    validate_sandbox_board(board)
-    target = _board_to_target(board)
+    validate_sandbox_board(target)
+    build_target = f"sandbox-{target}"
     if print_path:
         if not project:
             raise click.ClickException(
                 "`--print-path` requires `--app NAME` — there is no canonical "
                 "artifact path without a specific project."
             )
-        click.echo(str(artifact_path(target, project, config)))
+        click.echo(str(artifact_path(build_target, project, config)))
         return
-    click.echo(f"Collecting artifacts for {board} sandbox ({config})...", err=True)
-    elapsed = run_make(target, config, make_targets=["artifacts"], quiet=not verbose)
+    click.echo(f"Collecting artifacts for {target} sandbox ({config})...", err=True)
+    elapsed = run_make(
+        build_target, config, make_targets=["artifacts"], quiet=not verbose
+    )
     click.echo(f"✓ Artifacts collected in {elapsed:.1f}s", err=True)
+    artifacts_dir = resolve_firmware_repo() / "artifacts"
+    if artifacts_dir.is_dir():
+        for p in sorted(artifacts_dir.glob(f"*-{build_target}.bin")):
+            click.echo(str(p))

--- a/dotbot/cli/fw.py
+++ b/dotbot/cli/fw.py
@@ -29,6 +29,7 @@ from dotbot.cli._fw_helpers import (
     DEFAULT_CONFIG,
     artifact_path,
     list_projects,
+    resolve_firmware_repo,
     run_make,
     validate_bare_target,
 )
@@ -53,29 +54,50 @@ def cmd():
     pass
 
 
+def _target_option(f):
+    """Reusable `--target/-t` option for build/clean/artifacts."""
+    return click.option(
+        "--target",
+        "-t",
+        default=DEFAULT_BARE_TARGET,
+        show_default=True,
+        help=(
+            "BUILD_TARGET (e.g. dotbot-v3, nrf5340dk-app, sailbot-v1). "
+            "See `dotbot fw targets` for the full list."
+        ),
+    )(f)
+
+
 def _project_option(f):
-    """Reusable `--app NAME` option for build/clean/artifacts."""
+    """Reusable `--app/-a NAME` option for build/clean/artifacts."""
     return click.option(
         "--app",
+        "-a",
         "project",
         type=str,
         default=None,
         help=(
             "Build a single app (e.g. `dotbot`, `dotbot_gateway`). "
-            "Default: build every app available for TARGET."
+            "Default: build every app available for the target."
         ),
     )(f)
 
 
+def _config_option(f):
+    """Reusable `--config/-c` option for build/clean/artifacts."""
+    return click.option(
+        "--config",
+        "-c",
+        type=click.Choice(CONFIGS),
+        default=DEFAULT_CONFIG,
+        show_default=True,
+    )(f)
+
+
 @cmd.command()
-@click.argument("target", default=DEFAULT_BARE_TARGET)
+@_target_option
 @_project_option
-@click.option(
-    "--config",
-    type=click.Choice(CONFIGS),
-    default=DEFAULT_CONFIG,
-    show_default=True,
-)
+@_config_option
 @click.option(
     "--rebuild",
     is_flag=True,
@@ -90,39 +112,33 @@ def _project_option(f):
     help="Show full SES `-verbose -echo` output.",
 )
 def build(target, project, config, rebuild, verbose):
-    """Build bare DotBot firmware for TARGET (default: dotbot-v3)."""
+    """Build bare DotBot firmware (default target: dotbot-v3)."""
     validate_bare_target(target)
-    if project:
-        valid = list_projects(target)
-        if project not in valid:
-            raise click.ClickException(
-                f"App {project!r} is not available for target {target!r}.\n"
-                f"Available: {', '.join(valid)}"
-            )
+    apps_to_build = [project] if project else list_projects(target)
+    if project and project not in list_projects(target):
+        raise click.ClickException(
+            f"App {project!r} is not available for target {target!r}.\n"
+            f"Available: {', '.join(list_projects(target))}"
+        )
     mode = "rebuild" if rebuild else "incremental"
     what = project or "all apps"
     click.echo(f"Building {what} for {target} ({config}, {mode})...", err=True)
     elapsed = run_make(target, config, project, rebuild=rebuild, quiet=not verbose)
     click.echo(f"✓ Built {target} in {elapsed:.1f}s", err=True)
-    # Single-artifact case: echo the path to stdout so the user can
-    # pipe it (e.g. `dotbot fw build dotbot-v3 --app dotbot | tail -1`).
-    if project:
-        out = artifact_path(target, project, config)
+    # Echo each produced artifact path on its own stdout line so pipelines
+    # like `dotbot fw build | xargs -n1 nrfjprog --program` work.
+    for app in apps_to_build:
+        out = artifact_path(target, app, config)
         if out.is_file():
             click.echo(str(out))
 
 
 @cmd.command()
-@click.argument("target", default=DEFAULT_BARE_TARGET)
-@click.option(
-    "--config",
-    type=click.Choice(CONFIGS),
-    default=DEFAULT_CONFIG,
-    show_default=True,
-)
+@_target_option
+@_config_option
 @click.option("-v", "--verbose", is_flag=True, default=False)
 def clean(target, config, verbose):
-    """Clean SES build outputs for TARGET (per BUILD_CONFIG)."""
+    """Clean SES build outputs (default target: dotbot-v3)."""
     validate_bare_target(target)
     click.echo(f"Cleaning {target} ({config})...", err=True)
     elapsed = run_make(target, config, make_targets=["clean"], quiet=not verbose)
@@ -137,14 +153,9 @@ def list_targets():
 
 
 @cmd.command()
-@click.argument("target", default=DEFAULT_BARE_TARGET)
+@_target_option
 @_project_option
-@click.option(
-    "--config",
-    type=click.Choice(CONFIGS),
-    default=DEFAULT_CONFIG,
-    show_default=True,
-)
+@_config_option
 @click.option(
     "--print-path",
     is_flag=True,
@@ -166,6 +177,13 @@ def artifacts(target, project, config, print_path, verbose):
     click.echo(f"Collecting artifacts for {target} ({config})...", err=True)
     elapsed = run_make(target, config, make_targets=["artifacts"], quiet=not verbose)
     click.echo(f"✓ Artifacts collected in {elapsed:.1f}s", err=True)
+    # Echo every collected artifact path on its own stdout line so the user
+    # sees what's in `artifacts/` without a separate `ls`.
+    artifacts_dir = resolve_firmware_repo() / "artifacts"
+    if artifacts_dir.is_dir():
+        ext = "bin" if target.startswith("sandbox-") else "hex"
+        for p in sorted(artifacts_dir.glob(f"*-{target}.{ext}")):
+            click.echo(str(p))
 
 
 @cmd.command()

--- a/dotbot/cli/fw.py
+++ b/dotbot/cli/fw.py
@@ -99,8 +99,13 @@ def build(target, project, config, rebuild, verbose):
                 f"App {project!r} is not available for target {target!r}.\n"
                 f"Available: {', '.join(valid)}"
             )
-    run_make(target, config, project, rebuild=rebuild, quiet=not verbose)
-    # Echo where to find the output on success.
+    mode = "rebuild" if rebuild else "incremental"
+    what = project or "all apps"
+    click.echo(f"Building {what} for {target} ({config}, {mode})...", err=True)
+    elapsed = run_make(target, config, project, rebuild=rebuild, quiet=not verbose)
+    click.echo(f"✓ Built {target} in {elapsed:.1f}s", err=True)
+    # Single-artifact case: echo the path to stdout so the user can
+    # pipe it (e.g. `dotbot fw build dotbot-v3 --app dotbot | tail -1`).
     if project:
         out = artifact_path(target, project, config)
         if out.is_file():
@@ -119,7 +124,9 @@ def build(target, project, config, rebuild, verbose):
 def clean(target, config, verbose):
     """Clean SES build outputs for TARGET (per BUILD_CONFIG)."""
     validate_bare_target(target)
-    run_make(target, config, make_targets=["clean"], quiet=not verbose)
+    click.echo(f"Cleaning {target} ({config})...", err=True)
+    elapsed = run_make(target, config, make_targets=["clean"], quiet=not verbose)
+    click.echo(f"✓ Cleaned in {elapsed:.1f}s", err=True)
 
 
 @cmd.command(name="targets")
@@ -156,7 +163,9 @@ def artifacts(target, project, config, print_path, verbose):
             )
         click.echo(str(artifact_path(target, project, config)))
         return
-    run_make(target, config, make_targets=["artifacts"], quiet=not verbose)
+    click.echo(f"Collecting artifacts for {target} ({config})...", err=True)
+    elapsed = run_make(target, config, make_targets=["artifacts"], quiet=not verbose)
+    click.echo(f"✓ Artifacts collected in {elapsed:.1f}s", err=True)
 
 
 @cmd.command()

--- a/dotbot/cli/fw.py
+++ b/dotbot/cli/fw.py
@@ -18,7 +18,9 @@ build-only): firmware-scaffolding templates and the cabled-flash
 toolchain pickling each warrant their own design pass.
 """
 
+import shutil
 import sys
+from pathlib import Path
 
 import click
 
@@ -29,7 +31,6 @@ from dotbot.cli._fw_helpers import (
     DEFAULT_CONFIG,
     artifact_path,
     list_projects,
-    resolve_firmware_repo,
     run_make,
     validate_bare_target,
 )
@@ -157,14 +158,22 @@ def list_targets():
 @_project_option
 @_config_option
 @click.option(
+    "--out",
+    "out_dir",
+    type=click.Path(file_okay=False, dir_okay=True),
+    default="./artifacts",
+    show_default=True,
+    help="Where to put the collected artifacts (resolved against your CWD).",
+)
+@click.option(
     "--print-path",
     is_flag=True,
     default=False,
     help="Print where the artifact lives without building.",
 )
 @click.option("-v", "--verbose", is_flag=True, default=False)
-def artifacts(target, project, config, print_path, verbose):
-    """Build + collect canonical artifacts into `artifacts/`."""
+def artifacts(target, project, config, out_dir, print_path, verbose):
+    """Build + collect artifacts into ./artifacts/ (default)."""
     validate_bare_target(target)
     if print_path:
         if not project:
@@ -174,16 +183,32 @@ def artifacts(target, project, config, print_path, verbose):
             )
         click.echo(str(artifact_path(target, project, config)))
         return
-    click.echo(f"Collecting artifacts for {target} ({config})...", err=True)
-    elapsed = run_make(target, config, make_targets=["artifacts"], quiet=not verbose)
-    click.echo(f"✓ Artifacts collected in {elapsed:.1f}s", err=True)
-    # Echo every collected artifact path on its own stdout line so the user
-    # sees what's in `artifacts/` without a separate `ls`.
-    artifacts_dir = resolve_firmware_repo() / "artifacts"
-    if artifacts_dir.is_dir():
-        ext = "bin" if target.startswith("sandbox-") else "hex"
-        for p in sorted(artifacts_dir.glob(f"*-{target}.{ext}")):
-            click.echo(str(p))
+    out = Path(out_dir).resolve()
+    click.echo(
+        f"Building + collecting artifacts for {target} ({config}) → {out}/...",
+        err=True,
+    )
+    # Build (not `make artifacts` — that target's path formula is buggy
+    # for sandbox and writes to repos/DotBot-firmware/artifacts/ instead
+    # of the user's CWD). Force a full rebuild because bare and sandbox
+    # builds share the SES Output dir per board (`$(BuildTarget)` is the
+    # same in both .emProject files), so incremental can pick up stale
+    # objects from the other flavor and link-error.
+    elapsed = run_make(target, config, project, rebuild=True, quiet=not verbose)
+    out.mkdir(parents=True, exist_ok=True)
+    apps_to_collect = [project] if project else list_projects(target)
+    copied = []
+    for app in apps_to_collect:
+        src = artifact_path(target, app, config)
+        if src.is_file():
+            dst = out / src.name
+            shutil.copy2(src, dst)
+            copied.append(dst)
+    click.echo(
+        f"✓ Collected {len(copied)} artifact(s) in {elapsed:.1f}s", err=True
+    )
+    for p in copied:
+        click.echo(str(p))
 
 
 @cmd.command()

--- a/dotbot/cli/fw.py
+++ b/dotbot/cli/fw.py
@@ -204,9 +204,7 @@ def artifacts(target, project, config, out_dir, print_path, verbose):
             dst = out / src.name
             shutil.copy2(src, dst)
             copied.append(dst)
-    click.echo(
-        f"✓ Collected {len(copied)} artifact(s) in {elapsed:.1f}s", err=True
-    )
+    click.echo(f"✓ Collected {len(copied)} artifact(s) in {elapsed:.1f}s", err=True)
     for p in copied:
         click.echo(str(p))
 

--- a/dotbot/cli/fw.py
+++ b/dotbot/cli/fw.py
@@ -45,7 +45,8 @@ _NOT_READY = (
     help=(
         "Bare DotBot firmware: build, clean, list targets, collect artifacts. "
         "For TrustZone sandbox apps that run inside swarmit, see "
-        "`dotbot swarm fw`."
+        "`dotbot swarm fw`. Need a Makefile knob not covered by these flags? "
+        "Use `dotbot make --help`."
     ),
 )
 def cmd():

--- a/dotbot/cli/fw.py
+++ b/dotbot/cli/fw.py
@@ -1,34 +1,161 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""`dotbot fw` — firmware-developer workflow (mocked).
+"""`dotbot fw` — bare DotBot firmware build/clean/targets/artifacts.
 
-The CLI surface is wired so the help text is discoverable today, but
-the underlying build/flash/template machinery doesn't exist yet — it
-depends on a C toolchain pipeline (cmake + ninja + gcc-arm-none-eabi)
-and app templates that the firmware-unification work will deliver.
+Wraps `make BUILD_TARGET=... BUILD_CONFIG=...` in `repos/DotBot-firmware/`
+using SES (`emBuild`) — see the workspace AGENTS.md "Firmware builds —
+local SES" convention. `dotbot fw build` defaults to incremental
+(passes `BUILD_MODE=-build`) for a fast edit/build loop; pass
+`--rebuild` to force a full rebuild.
+
+Sandbox apps (TrustZone NS, OTA-flashed via swarmit) live behind a
+separate `dotbot swarm fw` subgroup — different mental model and
+different consumer toolchain. See `dotbot/cli/_sandbox_fw.py`.
+
+Subcommands `new` and `flash` remain mocked (Phase 1 scope is
+build-only): firmware-scaffolding templates and the cabled-flash
+toolchain pickling each warrant their own design pass.
 """
 
 import sys
 
 import click
 
+from dotbot.cli._fw_helpers import (
+    BARE_TARGETS,
+    CONFIGS,
+    DEFAULT_BARE_TARGET,
+    DEFAULT_CONFIG,
+    artifact_path,
+    list_projects,
+    run_make,
+    validate_bare_target,
+)
+
 _NOT_READY = (
     "`dotbot fw {sub}` is not implemented yet.\n"
-    "For now: use SEGGER Embedded Studio or the per-target Makefile in "
-    "`DotBot-firmware` / `dotbot-swarmit` / `dotbot-lh2-calibration`."
+    "For now: use SEGGER Embedded Studio directly, or invoke the "
+    "Makefile in `repos/DotBot-firmware`."
 )
 
 
 @click.group(
     name="fw",
     help=(
-        "Firmware-developer workflow: scaffold, build, USB-cable flash. "
-        "Currently a mock surface — subcommands print install instructions."
+        "Bare DotBot firmware: build, clean, list targets, collect artifacts. "
+        "For TrustZone sandbox apps that run inside swarmit, see "
+        "`dotbot swarm fw`."
     ),
 )
 def cmd():
     pass
+
+
+def _project_option(f):
+    """Reusable `--app NAME` option for build/clean/artifacts."""
+    return click.option(
+        "--app",
+        "project",
+        type=str,
+        default=None,
+        help=(
+            "Build a single app (e.g. `dotbot`, `dotbot_gateway`). "
+            "Default: build every app available for TARGET."
+        ),
+    )(f)
+
+
+@cmd.command()
+@click.argument("target", default=DEFAULT_BARE_TARGET)
+@_project_option
+@click.option(
+    "--config",
+    type=click.Choice(CONFIGS),
+    default=DEFAULT_CONFIG,
+    show_default=True,
+)
+@click.option(
+    "--rebuild",
+    is_flag=True,
+    default=False,
+    help="Force full rebuild (pass `-rebuild` to emBuild). Default: incremental.",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="Show full SES `-verbose -echo` output.",
+)
+def build(target, project, config, rebuild, verbose):
+    """Build bare DotBot firmware for TARGET (default: dotbot-v3)."""
+    validate_bare_target(target)
+    if project:
+        valid = list_projects(target)
+        if project not in valid:
+            raise click.ClickException(
+                f"App {project!r} is not available for target {target!r}.\n"
+                f"Available: {', '.join(valid)}"
+            )
+    run_make(target, config, project, rebuild=rebuild, quiet=not verbose)
+    # Echo where to find the output on success.
+    if project:
+        out = artifact_path(target, project, config)
+        if out.is_file():
+            click.echo(str(out))
+
+
+@cmd.command()
+@click.argument("target", default=DEFAULT_BARE_TARGET)
+@click.option(
+    "--config",
+    type=click.Choice(CONFIGS),
+    default=DEFAULT_CONFIG,
+    show_default=True,
+)
+@click.option("-v", "--verbose", is_flag=True, default=False)
+def clean(target, config, verbose):
+    """Clean SES build outputs for TARGET (per BUILD_CONFIG)."""
+    validate_bare_target(target)
+    run_make(target, config, make_targets=["clean"], quiet=not verbose)
+
+
+@cmd.command(name="targets")
+def list_targets():
+    """List valid BUILD_TARGETs for `dotbot fw build` (one per line)."""
+    for t in sorted(BARE_TARGETS):
+        click.echo(t)
+
+
+@cmd.command()
+@click.argument("target", default=DEFAULT_BARE_TARGET)
+@_project_option
+@click.option(
+    "--config",
+    type=click.Choice(CONFIGS),
+    default=DEFAULT_CONFIG,
+    show_default=True,
+)
+@click.option(
+    "--print-path",
+    is_flag=True,
+    default=False,
+    help="Print where the artifact lives without building.",
+)
+@click.option("-v", "--verbose", is_flag=True, default=False)
+def artifacts(target, project, config, print_path, verbose):
+    """Build + collect canonical artifacts into `artifacts/`."""
+    validate_bare_target(target)
+    if print_path:
+        if not project:
+            raise click.ClickException(
+                "`--print-path` requires `--app NAME` — there is no canonical "
+                "artifact path without a specific project."
+            )
+        click.echo(str(artifact_path(target, project, config)))
+        return
+    run_make(target, config, make_targets=["artifacts"], quiet=not verbose)
 
 
 @cmd.command()
@@ -46,17 +173,8 @@ def new(name, template):  # pylint: disable=unused-argument
 
 
 @cmd.command()
-@click.option("--target", type=str, help="Build target (e.g. dotbot-v3).")
-def build(target):  # pylint: disable=unused-argument
-    """Build firmware via cmake+ninja (NOT IMPLEMENTED)."""
-    click.echo(_NOT_READY.format(sub="build"), err=True)
-    sys.exit(2)
-
-
-@cmd.command()
 @click.argument("image", type=click.Path())
 @click.option("--serial", type=str, help="J-Link / nRF serial number.")
-@click.option("--bare/--swarmit", default=False, help="Bypass swarmit sandbox.")
 @click.option(
     "--component",
     type=click.Choice(["app", "bootloader", "netcore"]),
@@ -64,7 +182,7 @@ def build(target):  # pylint: disable=unused-argument
     show_default=True,
 )
 @click.option("--gateway", is_flag=True, help="Flash a gateway bot.")
-def flash(image, serial, bare, component, gateway):  # pylint: disable=unused-argument
+def flash(image, serial, component, gateway):  # pylint: disable=unused-argument
     """USB-cable flash an image to a single bot (NOT IMPLEMENTED)."""
     click.echo(_NOT_READY.format(sub="flash"), err=True)
     sys.exit(2)

--- a/dotbot/cli/main.py
+++ b/dotbot/cli/main.py
@@ -19,6 +19,11 @@ Adding a new subcommand:
      short help string shown in `dotbot --help`).
   3. If the backend lives in an optional sibling package, use
      `dotbot.cli._lazy.lazy_subcommand` inside that module.
+
+Deprecated aliases live in `_ALIASES`: old name → canonical name.
+Aliases are NOT listed in `_SUBCOMMANDS` (so they stay out of
+`dotbot --help`) but resolve at dispatch time with a one-line stderr
+warning. Drop the alias one release after introduction.
 """
 
 import importlib
@@ -41,9 +46,9 @@ _SUBCOMMANDS: Tuple[Tuple[str, str, str], ...] = (
         "Standalone simulator (equivalent to controller --adapter dotbot-simulator).",
     ),
     (
-        "testbed",
-        "dotbot.cli.testbed",
-        "Testbed-side ops: provision, status, start/stop, OTA flash, monitor.",
+        "swarm",
+        "dotbot.cli.swarm",
+        "Swarm-orchestration ops: provision, status, start/stop, OTA flash, sandbox fw.",
     ),
     (
         "calibrate-lh2",
@@ -54,11 +59,18 @@ _SUBCOMMANDS: Tuple[Tuple[str, str, str], ...] = (
     (
         "fw",
         "dotbot.cli.fw",
-        "Firmware-developer workflow (scaffold/build/flash). MOCK in Phase 1.",
+        "Bare DotBot firmware: build, clean, list targets, collect artifacts.",
     ),
     ("keyboard", "dotbot.cli.keyboard", "Drive a DotBot from the keyboard (live)."),
     ("joystick", "dotbot.cli.joystick", "Drive a DotBot from a joystick (live)."),
 )
+
+# Deprecated CLI names that route to a canonical subcommand. Print a
+# one-line stderr warning on dispatch so callers see the migration path.
+# Drop entries one release after they ship.
+_ALIASES = {
+    "testbed": "swarm",
+}
 
 _HELP_INDEX = {name: short for name, _, short in _SUBCOMMANDS}
 _MODULE_INDEX = {name: module_path for name, module_path, _ in _SUBCOMMANDS}
@@ -71,6 +83,14 @@ class _LazyGroup(click.Group):
         return [name for name, _, _ in _SUBCOMMANDS]
 
     def get_command(self, ctx, cmd_name) -> Optional[click.Command]:
+        canonical = _ALIASES.get(cmd_name)
+        if canonical is not None:
+            click.echo(
+                f"warning: 'dotbot {cmd_name}' is deprecated; "
+                f"use 'dotbot {canonical}' instead.",
+                err=True,
+            )
+            cmd_name = canonical
         module_path = _MODULE_INDEX.get(cmd_name)
         if module_path is None:
             return None
@@ -91,7 +111,7 @@ class _LazyGroup(click.Group):
 
 @click.group(
     cls=_LazyGroup,
-    help="Control DotBots: drive robots, run testbed experiments, calibrate, demos.",
+    help="Control DotBots: drive robots, run swarm experiments, calibrate, demos.",
 )
 @click.version_option(
     version=pydotbot_version(),

--- a/dotbot/cli/main.py
+++ b/dotbot/cli/main.py
@@ -61,6 +61,11 @@ _SUBCOMMANDS: Tuple[Tuple[str, str, str], ...] = (
         "dotbot.cli.fw",
         "Bare DotBot firmware: build, clean, list targets, collect artifacts.",
     ),
+    (
+        "make",
+        "dotbot.cli.make",
+        "Escape hatch: forward args to `make` in repos/DotBot-firmware/.",
+    ),
     ("keyboard", "dotbot.cli.keyboard", "Drive a DotBot from the keyboard (live)."),
     ("joystick", "dotbot.cli.joystick", "Drive a DotBot from a joystick (live)."),
 )

--- a/dotbot/cli/main.py
+++ b/dotbot/cli/main.py
@@ -19,11 +19,6 @@ Adding a new subcommand:
      short help string shown in `dotbot --help`).
   3. If the backend lives in an optional sibling package, use
      `dotbot.cli._lazy.lazy_subcommand` inside that module.
-
-Deprecated aliases live in `_ALIASES`: old name → canonical name.
-Aliases are NOT listed in `_SUBCOMMANDS` (so they stay out of
-`dotbot --help`) but resolve at dispatch time with a one-line stderr
-warning. Drop the alias one release after introduction.
 """
 
 import importlib
@@ -70,13 +65,6 @@ _SUBCOMMANDS: Tuple[Tuple[str, str, str], ...] = (
     ("joystick", "dotbot.cli.joystick", "Drive a DotBot from a joystick (live)."),
 )
 
-# Deprecated CLI names that route to a canonical subcommand. Print a
-# one-line stderr warning on dispatch so callers see the migration path.
-# Drop entries one release after they ship.
-_ALIASES = {
-    "testbed": "swarm",
-}
-
 _HELP_INDEX = {name: short for name, _, short in _SUBCOMMANDS}
 _MODULE_INDEX = {name: module_path for name, module_path, _ in _SUBCOMMANDS}
 
@@ -88,14 +76,6 @@ class _LazyGroup(click.Group):
         return [name for name, _, _ in _SUBCOMMANDS]
 
     def get_command(self, ctx, cmd_name) -> Optional[click.Command]:
-        canonical = _ALIASES.get(cmd_name)
-        if canonical is not None:
-            click.echo(
-                f"warning: 'dotbot {cmd_name}' is deprecated; "
-                f"use 'dotbot {canonical}' instead.",
-                err=True,
-            )
-            cmd_name = canonical
         module_path = _MODULE_INDEX.get(cmd_name)
         if module_path is None:
             return None

--- a/dotbot/cli/make.py
+++ b/dotbot/cli/make.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""`dotbot make` — escape hatch to `make` in `repos/DotBot-firmware/`.
+
+`dotbot fw build` (and `dotbot swarm fw build`) deliberately model only
+the flags that matter for the daily edit/build loop: TARGET, `--app`,
+`--config`, `--rebuild`, `-v`. Anything else (PACKAGES_DIR_OPT, DOCKER
+overrides, `make doc`, custom CLANG_FORMAT_TYPE, …) is intentionally
+not modelled — the Makefile is fully featured and the flag matrix
+shouldn't grow to chase it.
+
+This subcommand is the honest answer: it forwards arbitrary arguments
+to `make` in the firmware repo, with two affordances that bare `cd
+repos/DotBot-firmware && make ...` doesn't give you:
+
+1. SEGGER_DIR is auto-resolved (env → macOS default → clear error).
+2. The firmware repo is auto-located (workspace walk-up → env var).
+
+Everything else is plain make.
+"""
+
+import os
+import subprocess
+import sys
+
+import click
+
+from dotbot.cli._fw_helpers import resolve_firmware_repo, resolve_segger_dir
+
+
+@click.command(
+    name="make",
+    context_settings={
+        "ignore_unknown_options": True,
+        "allow_extra_args": True,
+        "help_option_names": ["-h", "--help"],
+    },
+    help=(
+        "Escape hatch: run `make` in repos/DotBot-firmware/ with "
+        "workspace-resolved SEGGER_DIR. Forwards all args verbatim. "
+        "Use this when `dotbot fw build` / `dotbot swarm fw build` "
+        "don't model the Makefile knob you need."
+    ),
+)
+@click.pass_context
+def cmd(ctx):
+    """Run `make` in the firmware repo. Examples:
+
+    \b
+        dotbot make help
+        dotbot make list-targets
+        dotbot make BUILD_TARGET=dotbot-v3 BUILD_CONFIG=Debug
+        dotbot make BUILD_TARGET=dotbot-v3 PACKAGES_DIR_OPT="-packagesdir /opt/pkgs"
+        dotbot make docker BUILD_TARGET=sandbox-dotbot-v3
+    """
+    repo = resolve_firmware_repo()
+    segger = resolve_segger_dir()
+    env = {**os.environ, "SEGGER_DIR": str(segger)}
+    sys.exit(subprocess.call(["make", *ctx.args], cwd=repo, env=env))

--- a/dotbot/cli/swarm.py
+++ b/dotbot/cli/swarm.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""`dotbot testbed` — provision, OTA-flash, start/stop/monitor.
+"""`dotbot swarm` — provision, OTA-flash, start/stop/monitor.
 
-Mounts the upstream `swarmit` Click group as the `dotbot testbed`
+Mounts the upstream `swarmit` Click group as the `dotbot swarm`
 parent (operators get `status|start|stop|flash|monitor|reset|message|
 calibrate-lh2` with their existing flags). swarmit stays external for
 now — folding it is Track A Phase 6.
@@ -14,6 +14,10 @@ dep `intelhex` is gated behind `pip install dotbot[provision]`; if
 intelhex is missing, invoking provision-dependent paths raises a
 ClickException with a clear message (the package itself imports
 cleanly thanks to a try/except around the intelhex import).
+
+Historical name: `dotbot testbed`. Still works as a deprecated alias
+(see `dotbot.cli.main._ALIASES`); slated for removal one release after
+the rename ships.
 """
 
 from dotbot.cli._lazy import lazy_subcommand
@@ -32,17 +36,17 @@ def _load_provision_group():
 
 
 cmd = lazy_subcommand(
-    name="testbed",
-    extra="testbed",
+    name="swarm",
+    extra="swarm",
     package="swarmit",
     help=(
-        "Testbed-side ops: provision, status, start/stop/monitor, OTA-flash. "
-        "Wraps swarmit + in-tree dotbot.provision."
+        "Swarm-orchestration ops: provision, status, start/stop/monitor, "
+        "OTA-flash. Wraps swarmit + in-tree dotbot.provision."
     ),
     loader=_load_swarmit_group,
 )
 
-# Mount in-tree provision as a subgroup of testbed. The import is
+# Mount in-tree provision as a subgroup of swarm. The import is
 # unconditional — `dotbot.provision.cli` doesn't require intelhex at
 # import time (it's optional and gated at command execution).
 if hasattr(cmd, "commands"):
@@ -50,6 +54,6 @@ if hasattr(cmd, "commands"):
         cmd.add_command(_load_provision_group(), name="provision")
     except Exception:  # pylint: disable=broad-except
         # Defensive: if for some reason dotbot.provision fails to import
-        # (unlikely — it's now in-tree), the testbed CLI still works
+        # (unlikely — it's now in-tree), the swarm CLI still works
         # without provision.
         pass

--- a/dotbot/cli/swarm.py
+++ b/dotbot/cli/swarm.py
@@ -14,10 +14,6 @@ dep `intelhex` is gated behind `pip install dotbot[provision]`; if
 intelhex is missing, invoking provision-dependent paths raises a
 ClickException with a clear message (the package itself imports
 cleanly thanks to a try/except around the intelhex import).
-
-Historical name: `dotbot testbed`. Still works as a deprecated alias
-(see `dotbot.cli.main._ALIASES`); slated for removal one release after
-the rename ships.
 """
 
 from dotbot.cli._lazy import lazy_subcommand

--- a/dotbot/cli/swarm.py
+++ b/dotbot/cli/swarm.py
@@ -35,20 +35,27 @@ def _load_provision_group():
     return provision_group
 
 
+def _load_sandbox_fw_group():
+    from dotbot.cli._sandbox_fw import cmd as sandbox_fw_group
+
+    return sandbox_fw_group
+
+
 cmd = lazy_subcommand(
     name="swarm",
     extra="swarm",
     package="swarmit",
     help=(
         "Swarm-orchestration ops: provision, status, start/stop/monitor, "
-        "OTA-flash. Wraps swarmit + in-tree dotbot.provision."
+        "OTA-flash, sandbox firmware build. Wraps swarmit + in-tree "
+        "dotbot.provision + dotbot.cli._sandbox_fw."
     ),
     loader=_load_swarmit_group,
 )
 
-# Mount in-tree provision as a subgroup of swarm. The import is
-# unconditional — `dotbot.provision.cli` doesn't require intelhex at
-# import time (it's optional and gated at command execution).
+# Mount in-tree provision + sandbox-fw as subgroups of swarm. The
+# imports are unconditional — neither module pulls in optional runtime
+# deps at module-import time.
 if hasattr(cmd, "commands"):
     try:
         cmd.add_command(_load_provision_group(), name="provision")
@@ -56,4 +63,8 @@ if hasattr(cmd, "commands"):
         # Defensive: if for some reason dotbot.provision fails to import
         # (unlikely — it's now in-tree), the swarm CLI still works
         # without provision.
+        pass
+    try:
+        cmd.add_command(_load_sandbox_fw_group(), name="fw")
+    except Exception:  # pylint: disable=broad-except
         pass

--- a/dotbot/tests/test_cli_dispatcher.py
+++ b/dotbot/tests/test_cli_dispatcher.py
@@ -53,12 +53,6 @@ EXPECTED_SUBCOMMANDS = {
     "joystick",
 }
 
-# Deprecated CLI names that route to a canonical subcommand. These are
-# NOT in `EXPECTED_SUBCOMMANDS` (they don't appear in `dotbot --help`)
-# but must keep working with a stderr deprecation warning until they're
-# dropped one release after the rename.
-_DEPRECATED_ALIASES = {"testbed": "swarm"}
-
 # Subcommands whose --help backends live in OTHER packages with their
 # own protocol registries (swarmit). When pytest pre-loads
 # dotbot.protocol via test_controller etc., importing swarmit in the
@@ -141,36 +135,6 @@ def test_cross_package_subcommand_help_works(subcommand):
     # Sanity: the help text should mention the subcommand or its purpose.
     combined = result.stdout + result.stderr
     assert "Usage" in combined
-
-
-@pytest.mark.parametrize("deprecated,canonical", sorted(_DEPRECATED_ALIASES.items()))
-def test_deprecated_alias_still_dispatches(deprecated, canonical):
-    """`dotbot testbed --help` (deprecated) routes to `dotbot swarm`."""
-    result = subprocess.run(
-        [sys.executable, "-m", "dotbot.cli", deprecated, "--help"],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    assert "Usage" in result.stdout + result.stderr
-    # The stderr warning must name both the old name and the canonical
-    # replacement, so callers see the migration path on first invocation.
-    assert deprecated in result.stderr
-    assert canonical in result.stderr
-    assert "deprecated" in result.stderr.lower()
-
-
-def test_deprecated_alias_not_in_help_listing(runner):
-    """Deprecated names stay out of `dotbot --help` so they don't get
-    re-adopted by readers."""
-    result = runner.invoke(cli, ["--help"])
-    assert result.exit_code == 0
-    for deprecated in _DEPRECATED_ALIASES:
-        assert deprecated not in result.output, (
-            f"deprecated alias `{deprecated}` should not appear in --help; "
-            "see _ALIASES in dotbot.cli.main"
-        )
 
 
 def test_fw_mock_exits_nonzero(runner):

--- a/dotbot/tests/test_cli_dispatcher.py
+++ b/dotbot/tests/test_cli_dispatcher.py
@@ -44,13 +44,19 @@ _needs_frontend = pytest.mark.skipif(
 EXPECTED_SUBCOMMANDS = {
     "controller",
     "sim",
-    "testbed",
+    "swarm",
     "calibrate-lh2",
     "demo",
     "fw",
     "keyboard",
     "joystick",
 }
+
+# Deprecated CLI names that route to a canonical subcommand. These are
+# NOT in `EXPECTED_SUBCOMMANDS` (they don't appear in `dotbot --help`)
+# but must keep working with a stderr deprecation warning until they're
+# dropped one release after the rename.
+_DEPRECATED_ALIASES = {"testbed": "swarm"}
 
 # Subcommands whose --help backends live in OTHER packages with their
 # own protocol registries (swarmit). When pytest pre-loads
@@ -63,7 +69,7 @@ EXPECTED_SUBCOMMANDS = {
 #
 # `calibrate` used to be in this set; after Phase 2's fold it's in-tree
 # and uses dotbot's own (vendored) modules, no collision possible.
-_CROSS_PACKAGE_SUBS = {"testbed"}
+_CROSS_PACKAGE_SUBS = {"swarm"}
 
 
 @pytest.fixture
@@ -101,9 +107,9 @@ def test_subcommand_help_works(runner, subcommand):
     """Every in-process subcommand's --help runs cleanly.
 
     keyboard/joystick are excluded because they import pygame/pynput at
-    module load time (headless-CI hostile). testbed/calibrate are
-    excluded because their backends collide with PyDotBot's protocol
-    registry inside a single pytest process — covered separately by
+    module load time (headless-CI hostile). swarm is excluded because
+    its swarmit backend collides with PyDotBot's protocol registry
+    inside a single pytest process — covered separately by
     test_cross_package_subcommand_help_works in a subprocess.
     controller/sim trigger dotbot.server's StaticFiles import-time mount;
     skipped if the frontend bundle hasn't been built.
@@ -118,7 +124,7 @@ def test_subcommand_help_works(runner, subcommand):
 
 @pytest.mark.parametrize("subcommand", sorted(_CROSS_PACKAGE_SUBS))
 def test_cross_package_subcommand_help_works(subcommand):
-    """`dotbot testbed --help` / `dotbot calibrate --help` in a clean process.
+    """`dotbot swarm --help` in a clean process.
 
     A subprocess avoids the swarmit/lh2-calibration vs PyDotBot
     protocol-registry collision that only manifests inside pytest's
@@ -134,6 +140,36 @@ def test_cross_package_subcommand_help_works(subcommand):
     # Sanity: the help text should mention the subcommand or its purpose.
     combined = result.stdout + result.stderr
     assert "Usage" in combined
+
+
+@pytest.mark.parametrize("deprecated,canonical", sorted(_DEPRECATED_ALIASES.items()))
+def test_deprecated_alias_still_dispatches(deprecated, canonical):
+    """`dotbot testbed --help` (deprecated) routes to `dotbot swarm`."""
+    result = subprocess.run(
+        [sys.executable, "-m", "dotbot.cli", deprecated, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert "Usage" in result.stdout + result.stderr
+    # The stderr warning must name both the old name and the canonical
+    # replacement, so callers see the migration path on first invocation.
+    assert deprecated in result.stderr
+    assert canonical in result.stderr
+    assert "deprecated" in result.stderr.lower()
+
+
+def test_deprecated_alias_not_in_help_listing(runner):
+    """Deprecated names stay out of `dotbot --help` so they don't get
+    re-adopted by readers."""
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    for deprecated in _DEPRECATED_ALIASES:
+        assert deprecated not in result.output, (
+            f"deprecated alias `{deprecated}` should not appear in --help; "
+            "see _ALIASES in dotbot.cli.main"
+        )
 
 
 def test_fw_mock_exits_nonzero(runner):

--- a/dotbot/tests/test_cli_dispatcher.py
+++ b/dotbot/tests/test_cli_dispatcher.py
@@ -48,6 +48,7 @@ EXPECTED_SUBCOMMANDS = {
     "calibrate-lh2",
     "demo",
     "fw",
+    "make",
     "keyboard",
     "joystick",
 }

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -16,6 +16,7 @@ rule isn't available.
 """
 
 import subprocess
+from pathlib import Path
 
 import click
 import pytest
@@ -482,20 +483,84 @@ def test_sandbox_fw_help_points_at_dotbot_make(runner):
 # ── Helper-level tests ──────────────────────────────────────────────────
 
 
-def test_resolve_segger_dir_uses_env_first(tmp_path, monkeypatch):
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """Point `~/.dotbot/` at a tmp dir so config tests don't see the
+    real user's `~/.dotbot/config.toml`."""
+    home = tmp_path / "home"
+    (home / ".dotbot").mkdir(parents=True)
+    monkeypatch.setattr(
+        "dotbot.cli._fw_helpers._CONFIG_PATH",
+        home / ".dotbot" / "config.toml",
+    )
+    return home
+
+
+def _write_config(home, toml_body):
+    (home / ".dotbot" / "config.toml").write_text(toml_body)
+
+
+def test_resolve_segger_dir_uses_env_first(tmp_path, monkeypatch, isolated_home):
+    """Env var beats config file beats glob."""
+    _write_config(isolated_home, '[fw]\nsegger_dir = "/from/config"\n')
     monkeypatch.setenv("SEGGER_DIR", str(tmp_path))
     assert _fw_helpers.resolve_segger_dir() == tmp_path
 
 
-def test_resolve_segger_dir_errors_when_unset_on_linux(monkeypatch):
+def test_resolve_segger_dir_falls_back_to_config(monkeypatch, isolated_home):
+    """When SEGGER_DIR is unset, `[fw].segger_dir` from the config wins."""
+    _write_config(isolated_home, '[fw]\nsegger_dir = "/from/config"\n')
+    monkeypatch.delenv("SEGGER_DIR", raising=False)
+    assert _fw_helpers.resolve_segger_dir() == Path("/from/config")
+
+
+def test_resolve_segger_dir_uses_macos_glob_when_no_env_or_config(
+    tmp_path, monkeypatch, isolated_home
+):
+    """macOS fallback: glob `/Applications/SEGGER/SEGGER Embedded Studio*`."""
+    monkeypatch.delenv("SEGGER_DIR", raising=False)
+    fake_install = tmp_path / "SEGGER Embedded Studio 9.99"
+    (fake_install / "bin").mkdir(parents=True)
+    (fake_install / "bin" / "emBuild").touch()
+    monkeypatch.setattr("dotbot.cli._fw_helpers.sys.platform", "darwin")
+    monkeypatch.setattr(
+        "dotbot.cli._fw_helpers._SEGGER_MACOS_GLOB",
+        str(tmp_path / "SEGGER Embedded Studio*"),
+    )
+    assert _fw_helpers.resolve_segger_dir() == fake_install
+
+
+def test_resolve_segger_dir_picks_latest_glob_match(
+    tmp_path, monkeypatch, isolated_home
+):
+    """Multiple SES installs → lexicographically-latest wins (newer version)."""
+    monkeypatch.delenv("SEGGER_DIR", raising=False)
+    for v in ("8.22a", "8.30a", "9.10"):
+        d = tmp_path / f"SEGGER Embedded Studio {v}" / "bin"
+        d.mkdir(parents=True)
+        (d / "emBuild").touch()
+    monkeypatch.setattr("dotbot.cli._fw_helpers.sys.platform", "darwin")
+    monkeypatch.setattr(
+        "dotbot.cli._fw_helpers._SEGGER_MACOS_GLOB",
+        str(tmp_path / "SEGGER Embedded Studio*"),
+    )
+    picked = _fw_helpers.resolve_segger_dir()
+    assert picked.name == "SEGGER Embedded Studio 9.10"
+
+
+def test_resolve_segger_dir_errors_when_nothing_found(monkeypatch, isolated_home):
     monkeypatch.delenv("SEGGER_DIR", raising=False)
     monkeypatch.setattr("dotbot.cli._fw_helpers.sys.platform", "linux")
     with pytest.raises(click.ClickException) as excinfo:
         _fw_helpers.resolve_segger_dir()
-    assert "SEGGER_DIR" in str(excinfo.value)
+    # Error message must surface BOTH escape hatches so the user can fix
+    # whichever they prefer.
+    msg = str(excinfo.value)
+    assert "SEGGER_DIR" in msg
+    assert "~/.dotbot/config.toml" in msg
 
 
-def test_resolve_firmware_repo_walks_up_from_cwd(tmp_path, monkeypatch):
+def test_resolve_firmware_repo_walks_up_from_cwd(tmp_path, monkeypatch, isolated_home):
     workspace = tmp_path / "ws"
     repo = workspace / "repos" / "DotBot-firmware"
     repo.mkdir(parents=True)
@@ -507,11 +572,56 @@ def test_resolve_firmware_repo_walks_up_from_cwd(tmp_path, monkeypatch):
     assert _fw_helpers.resolve_firmware_repo() == repo
 
 
-def test_resolve_firmware_repo_errors_outside_workspace(tmp_path, monkeypatch):
+def test_resolve_firmware_repo_uses_config_file(
+    tmp_path, monkeypatch, isolated_home
+):
+    """`[fw].firmware_repo` in the config beats workspace walk-up."""
+    real_repo = tmp_path / "outside-workspace" / "DotBot-firmware"
+    real_repo.mkdir(parents=True)
+    (real_repo / "Makefile").touch()
+    _write_config(isolated_home, f'[fw]\nfirmware_repo = "{real_repo}"\n')
+    monkeypatch.chdir(tmp_path)  # not inside any workspace
+    monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
+    assert _fw_helpers.resolve_firmware_repo() == real_repo
+
+
+def test_resolve_firmware_repo_config_pointing_at_no_makefile_errors(
+    tmp_path, monkeypatch, isolated_home
+):
+    """If the config points at a bad path, fail loudly — don't silently fall
+    through to the workspace walk-up."""
+    bad = tmp_path / "no-makefile-here"
+    bad.mkdir()
+    _write_config(isolated_home, f'[fw]\nfirmware_repo = "{bad}"\n')
+    monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
+    with pytest.raises(click.ClickException) as excinfo:
+        _fw_helpers.resolve_firmware_repo()
+    assert "firmware_repo" in str(excinfo.value)
+
+
+def test_resolve_firmware_repo_errors_outside_workspace(
+    tmp_path, monkeypatch, isolated_home
+):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
-    with pytest.raises(click.ClickException):
+    with pytest.raises(click.ClickException) as excinfo:
         _fw_helpers.resolve_firmware_repo()
+    msg = str(excinfo.value)
+    # Both escape hatches surfaced.
+    assert "DOTBOT_FIRMWARE_REPO" in msg
+    assert "~/.dotbot/config.toml" in msg
+
+
+def test_malformed_config_raises_with_path(monkeypatch, isolated_home):
+    _write_config(isolated_home, "this is not [valid toml\n")
+    with pytest.raises(click.ClickException) as excinfo:
+        _fw_helpers.load_config()
+    assert str(_fw_helpers._CONFIG_PATH) in str(excinfo.value)
+
+
+def test_missing_config_returns_empty_dict(isolated_home):
+    """No `~/.dotbot/config.toml` is the common case — must not error."""
+    assert _fw_helpers.load_config() == {}
 
 
 # ── Parity guard against silent drift ───────────────────────────────────

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -319,10 +319,11 @@ def test_sandbox_fw_artifacts_print_path_uses_bin_extension(
     )
     assert result.exit_code == 0, result.output
     out = result.output.strip()
-    # SES uses the board name (no sandbox- prefix) for the Output path
-    # — see `artifact_path()`'s docstring re. the `$(BuildTarget)` macro.
+    # SES's `$(BuildTarget)` macro now matches the make-level BUILD_TARGET
+    # (including the `sandbox-` prefix), so Output paths are flavor-distinct.
     assert out.endswith(
-        "apps-sandbox/dotbot/Output/dotbot-v3/Release/Exe/dotbot-dotbot-v3.bin"
+        "apps-sandbox/dotbot/Output/sandbox-dotbot-v3/Release/Exe/"
+        "dotbot-sandbox-dotbot-v3.bin"
     )
 
 
@@ -336,25 +337,25 @@ def test_sandbox_fw_clean_invokes_make_clean(
     assert "clean" in cmd
 
 
-def test_sandbox_fw_artifacts_prepends_sandbox_prefix_in_copy(
+def test_sandbox_fw_artifacts_collected_filename_distinct_from_bare(
     runner, fake_repo, fake_segger, capture_make, tmp_path, monkeypatch
 ):
-    """Sandbox artifacts get a `sandbox-` filename prefix at copy time so
-    they don't collide with bare artifacts in the same `./artifacts/` dir.
-    No upstream project rename needed; the user types `--app dotbot` in
-    the `dotbot swarm fw` namespace without re-stating 'sandbox'."""
-    # Pretend SES wrote a sandbox artifact in the expected location.
+    """Sandbox artifacts land in `./artifacts/` with a filename naturally
+    distinct from any bare equivalent — `dotbot-sandbox-dotbot-v3.bin`
+    vs bare `dotbot-dotbot-v3.hex` — because SES's `$(BuildTarget)` macro
+    now includes the `sandbox-` prefix. No CLI-side mangling required;
+    the user types `--app dotbot` in either namespace."""
     src_dir = (
         fake_repo
         / "apps-sandbox"
         / "dotbot"
         / "Output"
-        / "dotbot-v3"
+        / "sandbox-dotbot-v3"
         / "Release"
         / "Exe"
     )
     src_dir.mkdir(parents=True)
-    (src_dir / "dotbot-dotbot-v3.bin").write_bytes(b"\xde\xad\xbe\xef")
+    (src_dir / "dotbot-sandbox-dotbot-v3.bin").write_bytes(b"\xde\xad\xbe\xef")
     monkeypatch.setattr(
         "dotbot.cli._sandbox_fw.list_projects", lambda target: ["dotbot"]
     )
@@ -366,8 +367,7 @@ def test_sandbox_fw_artifacts_prepends_sandbox_prefix_in_copy(
     assert result.exit_code == 0, result.output
     collected = list(out.iterdir())
     assert len(collected) == 1
-    # Filename has the prefix; bare equivalent would be dotbot-dotbot-v3.hex.
-    assert collected[0].name == "sandbox-dotbot-dotbot-v3.bin"
+    assert collected[0].name == "dotbot-sandbox-dotbot-v3.bin"
 
 
 # ── Output polish: preamble, timing, gated make-line echo ───────────────

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -306,9 +306,10 @@ def test_sandbox_fw_artifacts_print_path_uses_bin_extension(
     )
     assert result.exit_code == 0, result.output
     out = result.output.strip()
+    # SES uses the board name (no sandbox- prefix) for the Output path
+    # — see `artifact_path()`'s docstring re. the `$(BuildTarget)` macro.
     assert out.endswith(
-        "apps-sandbox/dotbot/Output/sandbox-dotbot-v3/Release/Exe/"
-        "dotbot-sandbox-dotbot-v3.bin"
+        "apps-sandbox/dotbot/Output/dotbot-v3/Release/Exe/dotbot-dotbot-v3.bin"
     )
 
 

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -300,6 +300,94 @@ def test_sandbox_fw_clean_invokes_make_clean(
     assert "clean" in cmd
 
 
+# ── `dotbot make` escape hatch ──────────────────────────────────────────
+
+
+from dotbot.cli.make import cmd as make_cmd  # noqa: E402
+
+
+@pytest.fixture
+def capture_make_passthrough(monkeypatch):
+    """Capture `subprocess.call` in dotbot.cli.make (the escape hatch).
+
+    Distinct from `capture_make` (which patches `_fw_helpers.subprocess`)
+    because `make.py` imports `subprocess` directly.
+    """
+    calls = []
+
+    def fake_call(cmd, cwd=None, env=None):
+        calls.append({"cmd": cmd, "cwd": cwd, "env": env})
+        return 0
+
+    monkeypatch.setattr("dotbot.cli.make.subprocess.call", fake_call)
+    return calls
+
+
+def test_dotbot_make_help_lists_examples(runner):
+    result = runner.invoke(make_cmd, ["--help"])
+    assert result.exit_code == 0
+    # Help should call out the workspace-resolved SEGGER_DIR — that's the
+    # entire point vs. raw `cd repos/DotBot-firmware && make ...`.
+    assert "SEGGER_DIR" in result.output
+
+
+def test_dotbot_make_forwards_args_verbatim(
+    runner, fake_repo, fake_segger, capture_make_passthrough
+):
+    """`dotbot make foo bar BAZ=qux` invokes `make foo bar BAZ=qux`."""
+    result = runner.invoke(
+        make_cmd, ["help", "BUILD_TARGET=dotbot-v3", "PACKAGES_DIR_OPT=-p /opt"]
+    )
+    assert result.exit_code == 0
+    assert len(capture_make_passthrough) == 1
+    cmd = capture_make_passthrough[0]["cmd"]
+    assert cmd[0] == "make"
+    assert "help" in cmd
+    assert "BUILD_TARGET=dotbot-v3" in cmd
+    assert "PACKAGES_DIR_OPT=-p /opt" in cmd
+
+
+def test_dotbot_make_runs_in_firmware_repo(
+    runner, fake_repo, fake_segger, capture_make_passthrough
+):
+    result = runner.invoke(make_cmd, ["list-targets"])
+    assert result.exit_code == 0
+    assert capture_make_passthrough[0]["cwd"] == fake_repo
+
+
+def test_dotbot_make_injects_segger_dir(
+    runner, fake_repo, fake_segger, capture_make_passthrough
+):
+    """SEGGER_DIR is set in the make env regardless of what the user passes."""
+    result = runner.invoke(make_cmd, ["help"])
+    assert result.exit_code == 0
+    env = capture_make_passthrough[0]["env"]
+    assert env["SEGGER_DIR"] == str(fake_segger)
+
+
+def test_dotbot_make_propagates_make_exit_code(
+    runner, fake_repo, fake_segger, monkeypatch
+):
+    monkeypatch.setattr("dotbot.cli.make.subprocess.call", lambda *a, **kw: 7)
+    result = runner.invoke(make_cmd, ["bogus-target"])
+    assert result.exit_code == 7
+
+
+# ── Help-text footer pointing at the escape hatch ───────────────────────
+
+
+def test_fw_help_points_at_dotbot_make(runner):
+    result = runner.invoke(fw_cmd, ["--help"])
+    assert result.exit_code == 0
+    assert "dotbot make" in result.output
+
+
+def test_sandbox_fw_help_points_at_dotbot_make(runner):
+    result = runner.invoke(sandbox_fw_cmd, ["--help"])
+    assert result.exit_code == 0
+    assert "dotbot make" in result.output
+
+
 # ── Helper-level tests ──────────────────────────────────────────────────
 
 

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -211,6 +211,95 @@ def test_fw_flash_still_not_implemented(runner):
     assert "not implemented" in result.output.lower()
 
 
+# ── Sandbox subgroup (`dotbot swarm fw`) ────────────────────────────────
+# These tests invoke the sandbox-fw Click group directly, bypassing the
+# `dotbot swarm` parent (which loads swarmit and triggers the
+# protocol-registry collision documented in test_cli_dispatcher.py).
+
+
+from dotbot.cli._sandbox_fw import cmd as sandbox_fw_cmd  # noqa: E402
+
+
+def test_sandbox_fw_help_lists_real_subcommands(runner):
+    result = runner.invoke(sandbox_fw_cmd, ["--help"])
+    assert result.exit_code == 0
+    for sub in ("build", "clean", "targets", "artifacts"):
+        assert sub in result.output
+    # Cross-reference to the bare path:
+    assert "dotbot fw" in result.output
+    # `new` and `flash` aren't valid sandbox subcommands (no scaffolding,
+    # OTA flash lives under `dotbot swarm flash`).
+    assert "new" not in result.output
+    assert "flash" not in result.output
+
+
+def test_sandbox_fw_targets_lists_boards(runner):
+    result = runner.invoke(sandbox_fw_cmd, ["targets"])
+    assert result.exit_code == 0
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert "dotbot-v3" in lines
+    assert "nrf5340dk" in lines
+    # User-facing names — no `sandbox-` prefix:
+    assert not any(ln.startswith("sandbox-") for ln in lines)
+
+
+def test_sandbox_fw_build_rejects_sandbox_prefix(runner):
+    """User shouldn't pass `sandbox-dotbot-v3` — drop the prefix."""
+    result = runner.invoke(sandbox_fw_cmd, ["build", "sandbox-dotbot-v3"])
+    assert result.exit_code != 0
+    assert "Drop the `sandbox-` prefix" in result.output
+
+
+def test_sandbox_fw_build_rejects_unknown_board(runner):
+    result = runner.invoke(sandbox_fw_cmd, ["build", "dotbot-v9"])
+    assert result.exit_code != 0
+    assert "Unknown sandbox board" in result.output
+
+
+def test_sandbox_fw_build_prepends_sandbox_prefix_to_target(
+    runner, fake_repo, fake_segger, capture_make
+):
+    """User-typed `dotbot-v3` becomes `BUILD_TARGET=sandbox-dotbot-v3`."""
+    result = runner.invoke(sandbox_fw_cmd, ["build", "dotbot-v3"])
+    assert result.exit_code == 0, result.output
+    cmd = capture_make[0]["cmd"]
+    assert "BUILD_TARGET=sandbox-dotbot-v3" in cmd
+
+
+def test_sandbox_fw_build_default_board(runner, fake_repo, fake_segger, capture_make):
+    result = runner.invoke(sandbox_fw_cmd, ["build"])
+    assert result.exit_code == 0, result.output
+    cmd = capture_make[0]["cmd"]
+    assert "BUILD_TARGET=sandbox-dotbot-v3" in cmd
+    assert "BUILD_CONFIG=Release" in cmd
+
+
+def test_sandbox_fw_artifacts_print_path_uses_bin_extension(
+    runner, fake_repo, fake_segger
+):
+    """Sandbox artifacts are `.bin` (what swarmit OTA flashes), not `.hex`."""
+    result = runner.invoke(
+        sandbox_fw_cmd,
+        ["artifacts", "dotbot-v3", "--app", "dotbot", "--print-path"],
+    )
+    assert result.exit_code == 0, result.output
+    out = result.output.strip()
+    assert out.endswith(
+        "apps-sandbox/dotbot/Output/sandbox-dotbot-v3/Release/Exe/"
+        "dotbot-sandbox-dotbot-v3.bin"
+    )
+
+
+def test_sandbox_fw_clean_invokes_make_clean(
+    runner, fake_repo, fake_segger, capture_make
+):
+    result = runner.invoke(sandbox_fw_cmd, ["clean", "dotbot-v3"])
+    assert result.exit_code == 0, result.output
+    cmd = capture_make[0]["cmd"]
+    assert "BUILD_TARGET=sandbox-dotbot-v3" in cmd
+    assert "clean" in cmd
+
+
 # ── Helper-level tests ──────────────────────────────────────────────────
 
 

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -55,14 +55,28 @@ def fake_segger(tmp_path, monkeypatch):
 
 @pytest.fixture
 def capture_make(monkeypatch):
-    """Replace `subprocess.call` so we capture the make command line."""
+    """Stub `subprocess.call` (the actual `make` invocation) and
+    `subprocess.run` (used by `list_projects` to enumerate buildable
+    apps) so the test never touches a real Makefile.
+    """
     calls = []
 
     def fake_call(cmd, cwd=None, env=None):
         calls.append({"cmd": cmd, "cwd": cwd, "env": env})
         return 0
 
+    def fake_run(cmd, cwd=None, env=None, **kw):
+        # Mimic `make -s list-projects` returning a small default set
+        # so build() can enumerate "apps to build" without erroring.
+        class _R:
+            returncode = 0
+            stdout = "dotbot\nlh2_calibration\nlog_dump\n"
+            stderr = ""
+
+        return _R()
+
     monkeypatch.setattr("dotbot.cli._fw_helpers.subprocess.call", fake_call)
+    monkeypatch.setattr("dotbot.cli._fw_helpers.subprocess.run", fake_run)
     return calls
 
 
@@ -89,13 +103,13 @@ def test_fw_targets_lists_bare_targets_one_per_line(runner):
 
 def test_fw_build_rejects_sandbox_target_with_redirect_hint(runner):
     """Sandbox targets must be rejected with a pointer to `swarm fw`."""
-    result = runner.invoke(fw_cmd, ["build", "sandbox-dotbot-v3"])
+    result = runner.invoke(fw_cmd, ["build", "--target", "sandbox-dotbot-v3"])
     assert result.exit_code != 0
     assert "swarm fw build dotbot-v3" in result.output
 
 
 def test_fw_build_rejects_unknown_target_with_suggestion(runner):
-    result = runner.invoke(fw_cmd, ["build", "dotbotv3"])  # missing dash
+    result = runner.invoke(fw_cmd, ["build", "--target", "dotbotv3"])  # missing dash
     assert result.exit_code != 0
     assert "dotbot-v3" in result.output  # didyoumean suggestion
 
@@ -116,7 +130,7 @@ def test_fw_build_passes_incremental_by_default(
     runner, fake_repo, fake_segger, capture_make
 ):
     """Default is `BUILD_MODE=-build` (incremental) for fast edit/build loop."""
-    result = runner.invoke(fw_cmd, ["build", "dotbot-v3"])
+    result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     cmd = capture_make[0]["cmd"]
     assert "BUILD_MODE=-build" in cmd
@@ -126,7 +140,7 @@ def test_fw_build_passes_incremental_by_default(
 def test_fw_build_rebuild_flag_forces_full_rebuild(
     runner, fake_repo, fake_segger, capture_make
 ):
-    result = runner.invoke(fw_cmd, ["build", "dotbot-v3", "--rebuild"])
+    result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v3", "--rebuild"])
     assert result.exit_code == 0, result.output
     cmd = capture_make[0]["cmd"]
     assert "BUILD_MODE=-rebuild" in cmd
@@ -134,14 +148,14 @@ def test_fw_build_rebuild_flag_forces_full_rebuild(
 
 def test_fw_build_quiet_by_default(runner, fake_repo, fake_segger, capture_make):
     """Default is `QUIET=1` to suppress SES `-verbose -echo` flood."""
-    result = runner.invoke(fw_cmd, ["build", "dotbot-v3"])
+    result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     cmd = capture_make[0]["cmd"]
     assert "QUIET=1" in cmd
 
 
 def test_fw_build_verbose_drops_quiet(runner, fake_repo, fake_segger, capture_make):
-    result = runner.invoke(fw_cmd, ["build", "dotbot-v3", "-v"])
+    result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v3", "-v"])
     assert result.exit_code == 0, result.output
     cmd = capture_make[0]["cmd"]
     assert "QUIET=1" not in cmd
@@ -154,7 +168,7 @@ def test_fw_build_with_app_appends_project_name(
     monkeypatch.setattr(
         "dotbot.cli.fw.list_projects", lambda target: ["dotbot", "lh2_calibration"]
     )
-    result = runner.invoke(fw_cmd, ["build", "dotbot-v3", "--app", "dotbot"])
+    result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v3", "--app", "dotbot"])
     assert result.exit_code == 0, result.output
     cmd = capture_make[0]["cmd"]
     assert cmd[-1] == "dotbot"
@@ -165,13 +179,13 @@ def test_fw_build_rejects_unavailable_project(
 ):
     """Project not in the post-filter list is rejected pre-make."""
     monkeypatch.setattr("dotbot.cli.fw.list_projects", lambda target: ["dotbot"])
-    result = runner.invoke(fw_cmd, ["build", "dotbot-v1", "--app", "dotbot_gateway"])
+    result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v1", "--app", "dotbot_gateway"])
     assert result.exit_code != 0
     assert "not available" in result.output
 
 
 def test_fw_clean_invokes_make_clean(runner, fake_repo, fake_segger, capture_make):
-    result = runner.invoke(fw_cmd, ["clean", "dotbot-v3"])
+    result = runner.invoke(fw_cmd, ["clean", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     cmd = capture_make[0]["cmd"]
     assert "BUILD_TARGET=dotbot-v3" in cmd
@@ -181,7 +195,7 @@ def test_fw_clean_invokes_make_clean(runner, fake_repo, fake_segger, capture_mak
 def test_fw_artifacts_invokes_make_artifacts(
     runner, fake_repo, fake_segger, capture_make
 ):
-    result = runner.invoke(fw_cmd, ["artifacts", "dotbot-v3"])
+    result = runner.invoke(fw_cmd, ["artifacts", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     cmd = capture_make[0]["cmd"]
     assert "artifacts" in cmd
@@ -189,7 +203,7 @@ def test_fw_artifacts_invokes_make_artifacts(
 
 def test_fw_artifacts_print_path_requires_app(runner, fake_repo, fake_segger):
     """`--print-path` without `--app` exits with a hint."""
-    result = runner.invoke(fw_cmd, ["artifacts", "dotbot-v3", "--print-path"])
+    result = runner.invoke(fw_cmd, ["artifacts", "--target", "dotbot-v3", "--print-path"])
     assert result.exit_code != 0
     assert "--app" in result.output
 
@@ -198,7 +212,7 @@ def test_fw_artifacts_print_path_returns_makefile_formula(
     runner, fake_repo, fake_segger
 ):
     result = runner.invoke(
-        fw_cmd, ["artifacts", "dotbot-v3", "--app", "dotbot", "--print-path"]
+        fw_cmd, ["artifacts", "--target", "dotbot-v3", "--app", "dotbot", "--print-path"]
     )
     assert result.exit_code == 0, result.output
     out = result.output.strip()
@@ -253,13 +267,13 @@ def test_sandbox_fw_targets_lists_boards(runner):
 
 def test_sandbox_fw_build_rejects_sandbox_prefix(runner):
     """User shouldn't pass `sandbox-dotbot-v3` — drop the prefix."""
-    result = runner.invoke(sandbox_fw_cmd, ["build", "sandbox-dotbot-v3"])
+    result = runner.invoke(sandbox_fw_cmd, ["build", "--target", "sandbox-dotbot-v3"])
     assert result.exit_code != 0
     assert "Drop the `sandbox-` prefix" in result.output
 
 
 def test_sandbox_fw_build_rejects_unknown_board(runner):
-    result = runner.invoke(sandbox_fw_cmd, ["build", "dotbot-v9"])
+    result = runner.invoke(sandbox_fw_cmd, ["build", "--target", "dotbot-v9"])
     assert result.exit_code != 0
     assert "Unknown sandbox board" in result.output
 
@@ -268,7 +282,7 @@ def test_sandbox_fw_build_prepends_sandbox_prefix_to_target(
     runner, fake_repo, fake_segger, capture_make
 ):
     """User-typed `dotbot-v3` becomes `BUILD_TARGET=sandbox-dotbot-v3`."""
-    result = runner.invoke(sandbox_fw_cmd, ["build", "dotbot-v3"])
+    result = runner.invoke(sandbox_fw_cmd, ["build", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     cmd = capture_make[0]["cmd"]
     assert "BUILD_TARGET=sandbox-dotbot-v3" in cmd
@@ -288,7 +302,7 @@ def test_sandbox_fw_artifacts_print_path_uses_bin_extension(
     """Sandbox artifacts are `.bin` (what swarmit OTA flashes), not `.hex`."""
     result = runner.invoke(
         sandbox_fw_cmd,
-        ["artifacts", "dotbot-v3", "--app", "dotbot", "--print-path"],
+        ["artifacts", "--target", "dotbot-v3", "--app", "dotbot", "--print-path"],
     )
     assert result.exit_code == 0, result.output
     out = result.output.strip()
@@ -301,7 +315,7 @@ def test_sandbox_fw_artifacts_print_path_uses_bin_extension(
 def test_sandbox_fw_clean_invokes_make_clean(
     runner, fake_repo, fake_segger, capture_make
 ):
-    result = runner.invoke(sandbox_fw_cmd, ["clean", "dotbot-v3"])
+    result = runner.invoke(sandbox_fw_cmd, ["clean", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     cmd = capture_make[0]["cmd"]
     assert "BUILD_TARGET=sandbox-dotbot-v3" in cmd
@@ -315,7 +329,7 @@ def test_fw_build_quiet_does_not_echo_make_line(
     runner, fake_repo, fake_segger, capture_make
 ):
     """Default (no -v): make command line stays out of output."""
-    result = runner.invoke(fw_cmd, ["build", "dotbot-v3"])
+    result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     assert "$ make" not in result.output
 
@@ -324,7 +338,7 @@ def test_fw_build_verbose_echoes_make_line(
     runner, fake_repo, fake_segger, capture_make
 ):
     """-v echoes the full make command so it's copy-pasteable."""
-    result = runner.invoke(fw_cmd, ["build", "dotbot-v3", "-v"])
+    result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v3", "-v"])
     assert result.exit_code == 0, result.output
     assert "$ make" in result.output
     assert "BUILD_TARGET=dotbot-v3" in result.output
@@ -334,7 +348,7 @@ def test_fw_build_prints_preamble_and_success(
     runner, fake_repo, fake_segger, capture_make
 ):
     """Happy path: preamble before make, success line with timing after."""
-    result = runner.invoke(fw_cmd, ["build", "dotbot-v3"])
+    result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     assert "Building" in result.output
     assert "dotbot-v3" in result.output
@@ -348,7 +362,7 @@ def test_fw_build_prints_preamble_and_success(
 def test_fw_build_rebuild_says_rebuild_in_preamble(
     runner, fake_repo, fake_segger, capture_make
 ):
-    result = runner.invoke(fw_cmd, ["build", "dotbot-v3", "--rebuild"])
+    result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v3", "--rebuild"])
     assert result.exit_code == 0, result.output
     assert "rebuild" in result.output
     assert "incremental" not in result.output
@@ -357,7 +371,7 @@ def test_fw_build_rebuild_says_rebuild_in_preamble(
 def test_fw_clean_prints_cleaned_success_line(
     runner, fake_repo, fake_segger, capture_make
 ):
-    result = runner.invoke(fw_cmd, ["clean", "dotbot-v3"])
+    result = runner.invoke(fw_cmd, ["clean", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     assert "Cleaning dotbot-v3" in result.output
     assert "✓ Cleaned" in result.output
@@ -366,7 +380,7 @@ def test_fw_clean_prints_cleaned_success_line(
 def test_fw_artifacts_prints_collected_success_line(
     runner, fake_repo, fake_segger, capture_make
 ):
-    result = runner.invoke(fw_cmd, ["artifacts", "dotbot-v3"])
+    result = runner.invoke(fw_cmd, ["artifacts", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     assert "Collecting artifacts" in result.output
     assert "✓ Artifacts collected" in result.output
@@ -385,7 +399,7 @@ def test_run_make_returns_elapsed_seconds(fake_repo, fake_segger, monkeypatch):
 def test_sandbox_fw_build_prints_preamble(
     runner, fake_repo, fake_segger, capture_make
 ):
-    result = runner.invoke(sandbox_fw_cmd, ["build", "dotbot-v3"])
+    result = runner.invoke(sandbox_fw_cmd, ["build", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     assert "Building" in result.output
     assert "sandbox" in result.output.lower()

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -7,8 +7,15 @@ These tests stub `subprocess.call` / `subprocess.run` so they don't
 need a SEGGER install or a DotBot-firmware checkout — they verify the
 CLI's argument shape, validations, and the command line passed to
 make, not the actual build.
+
+The single exception is `test_bare_targets_match_makefile_list_targets`,
+which shells out to `make list-targets` in the real DotBot-firmware
+repo to catch silent drift between the CLI's hardcoded enums and the
+Makefile. It self-skips if the workspace layout or the `list-targets`
+rule isn't available.
 """
 
+import subprocess
 
 import click
 import pytest
@@ -505,3 +512,63 @@ def test_resolve_firmware_repo_errors_outside_workspace(tmp_path, monkeypatch):
     monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
     with pytest.raises(click.ClickException):
         _fw_helpers.resolve_firmware_repo()
+
+
+# ── Parity guard against silent drift ───────────────────────────────────
+
+
+def _real_firmware_repo_or_skip():
+    """Find the real DotBot-firmware repo for the parity test, or skip."""
+    import os
+    from pathlib import Path
+
+    env = os.environ.get("DOTBOT_FIRMWARE_REPO")
+    if env and (Path(env) / "Makefile").is_file():
+        return Path(env)
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "repos" / "DotBot-firmware"
+        if (candidate / "Makefile").is_file():
+            return candidate
+    pytest.skip(
+        "Could not locate the real DotBot-firmware repo; set "
+        "DOTBOT_FIRMWARE_REPO or run from inside the workspace."
+    )
+
+
+def test_targets_match_makefile_list_targets():
+    """`set(BARE_TARGETS) | set('sandbox-'+SANDBOX_BOARDS)` must equal what
+    the Makefile reports via `make list-targets`.
+
+    Catches the silent drift case where someone adds e.g. dotbot-v4 to
+    the Makefile and forgets to update the CLI's hardcoded enum.
+
+    Self-skips if the real DotBot-firmware repo or the `list-targets`
+    Make rule isn't available (older checkout pre-dating that commit).
+    """
+    repo = _real_firmware_repo_or_skip()
+    try:
+        result = subprocess.run(
+            ["make", "-s", "list-targets"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pytest.skip("`make list-targets` not runnable in this environment.")
+    if result.returncode != 0:
+        pytest.skip(
+            "`make list-targets` rule not present in this DotBot-firmware "
+            "checkout. Bump the submodule / pull a newer Makefile to enable "
+            "this parity guard."
+        )
+    makefile_targets = {line.strip() for line in result.stdout.splitlines() if line.strip()}
+    cli_targets = set(_fw_helpers.BARE_TARGETS) | {
+        f"sandbox-{b}" for b in _fw_helpers.SANDBOX_BOARDS
+    }
+    assert makefile_targets == cli_targets, (
+        f"CLI hardcoded targets drifted from Makefile.\n"
+        f"In CLI but not Makefile: {cli_targets - makefile_targets}\n"
+        f"In Makefile but not CLI: {makefile_targets - cli_targets}"
+    )

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -236,7 +236,16 @@ def test_fw_artifacts_print_path_returns_makefile_formula(
     )
     assert result.exit_code == 0, result.output
     out = result.output.strip()
-    assert out.endswith("apps/dotbot/Output/dotbot-v3/Release/Exe/dotbot-dotbot-v3.hex")
+    expected = str(
+        Path("apps")
+        / "dotbot"
+        / "Output"
+        / "dotbot-v3"
+        / "Release"
+        / "Exe"
+        / "dotbot-dotbot-v3.hex"
+    )
+    assert out.endswith(expected)
 
 
 def test_fw_new_still_not_implemented(runner):
@@ -328,10 +337,16 @@ def test_sandbox_fw_artifacts_print_path_uses_bin_extension(
     out = result.output.strip()
     # SES's `$(BuildTarget)` macro now matches the make-level BUILD_TARGET
     # (including the `sandbox-` prefix), so Output paths are flavor-distinct.
-    assert out.endswith(
-        "apps-sandbox/dotbot/Output/sandbox-dotbot-v3/Release/Exe/"
-        "dotbot-sandbox-dotbot-v3.bin"
+    expected = str(
+        Path("apps-sandbox")
+        / "dotbot"
+        / "Output"
+        / "sandbox-dotbot-v3"
+        / "Release"
+        / "Exe"
+        / "dotbot-sandbox-dotbot-v3.bin"
     )
+    assert out.endswith(expected)
 
 
 def test_sandbox_fw_clean_invokes_make_clean(
@@ -645,7 +660,11 @@ def test_resolve_firmware_repo_uses_config_file(tmp_path, monkeypatch, isolated_
     real_repo = tmp_path / "outside-workspace" / "DotBot-firmware"
     real_repo.mkdir(parents=True)
     (real_repo / "Makefile").touch()
-    _write_config(isolated_home, f'[fw]\nfirmware_repo = "{real_repo}"\n')
+    # `.as_posix()` keeps backslashes out of the TOML double-quoted
+    # string literal on Windows (where they'd be parsed as escapes).
+    _write_config(
+        isolated_home, f'[fw]\nfirmware_repo = "{real_repo.as_posix()}"\n'
+    )
     monkeypatch.chdir(tmp_path)  # not inside any workspace
     monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
     assert _fw_helpers.resolve_firmware_repo() == real_repo
@@ -658,7 +677,7 @@ def test_resolve_firmware_repo_config_pointing_at_no_makefile_errors(
     through to the workspace walk-up."""
     bad = tmp_path / "no-makefile-here"
     bad.mkdir()
-    _write_config(isolated_home, f'[fw]\nfirmware_repo = "{bad}"\n')
+    _write_config(isolated_home, f'[fw]\nfirmware_repo = "{bad.as_posix()}"\n')
     monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
     with pytest.raises(click.ClickException) as excinfo:
         _fw_helpers.resolve_firmware_repo()

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -300,6 +300,90 @@ def test_sandbox_fw_clean_invokes_make_clean(
     assert "clean" in cmd
 
 
+# ── Output polish: preamble, timing, gated make-line echo ───────────────
+
+
+def test_fw_build_quiet_does_not_echo_make_line(
+    runner, fake_repo, fake_segger, capture_make
+):
+    """Default (no -v): make command line stays out of output."""
+    result = runner.invoke(fw_cmd, ["build", "dotbot-v3"])
+    assert result.exit_code == 0, result.output
+    assert "$ make" not in result.output
+
+
+def test_fw_build_verbose_echoes_make_line(
+    runner, fake_repo, fake_segger, capture_make
+):
+    """-v echoes the full make command so it's copy-pasteable."""
+    result = runner.invoke(fw_cmd, ["build", "dotbot-v3", "-v"])
+    assert result.exit_code == 0, result.output
+    assert "$ make" in result.output
+    assert "BUILD_TARGET=dotbot-v3" in result.output
+
+
+def test_fw_build_prints_preamble_and_success(
+    runner, fake_repo, fake_segger, capture_make
+):
+    """Happy path: preamble before make, success line with timing after."""
+    result = runner.invoke(fw_cmd, ["build", "dotbot-v3"])
+    assert result.exit_code == 0, result.output
+    assert "Building" in result.output
+    assert "dotbot-v3" in result.output
+    assert "Release" in result.output
+    assert "incremental" in result.output
+    # Success line uses a check mark + timing.
+    assert "✓" in result.output
+    assert "Built dotbot-v3" in result.output
+
+
+def test_fw_build_rebuild_says_rebuild_in_preamble(
+    runner, fake_repo, fake_segger, capture_make
+):
+    result = runner.invoke(fw_cmd, ["build", "dotbot-v3", "--rebuild"])
+    assert result.exit_code == 0, result.output
+    assert "rebuild" in result.output
+    assert "incremental" not in result.output
+
+
+def test_fw_clean_prints_cleaned_success_line(
+    runner, fake_repo, fake_segger, capture_make
+):
+    result = runner.invoke(fw_cmd, ["clean", "dotbot-v3"])
+    assert result.exit_code == 0, result.output
+    assert "Cleaning dotbot-v3" in result.output
+    assert "✓ Cleaned" in result.output
+
+
+def test_fw_artifacts_prints_collected_success_line(
+    runner, fake_repo, fake_segger, capture_make
+):
+    result = runner.invoke(fw_cmd, ["artifacts", "dotbot-v3"])
+    assert result.exit_code == 0, result.output
+    assert "Collecting artifacts" in result.output
+    assert "✓ Artifacts collected" in result.output
+
+
+def test_run_make_returns_elapsed_seconds(fake_repo, fake_segger, monkeypatch):
+    """`run_make` must return a float so subcommands can format the timing."""
+    monkeypatch.setattr(
+        "dotbot.cli._fw_helpers.subprocess.call", lambda *a, **kw: 0
+    )
+    elapsed = _fw_helpers.run_make("dotbot-v3", "Release", "dotbot")
+    assert isinstance(elapsed, float)
+    assert elapsed >= 0
+
+
+def test_sandbox_fw_build_prints_preamble(
+    runner, fake_repo, fake_segger, capture_make
+):
+    result = runner.invoke(sandbox_fw_cmd, ["build", "dotbot-v3"])
+    assert result.exit_code == 0, result.output
+    assert "Building" in result.output
+    assert "sandbox" in result.output.lower()
+    assert "✓ Built" in result.output
+
+
 # ── `dotbot make` escape hatch ──────────────────────────────────────────
 
 

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -129,11 +129,13 @@ def test_fw_build_default_target_is_dotbot_v3(
 def test_fw_build_passes_incremental_by_default(
     runner, fake_repo, fake_segger, capture_make
 ):
-    """Default is `BUILD_MODE=-build` (incremental) for fast edit/build loop."""
+    """Default is `BUILD_MODE=` (empty → emBuild's natural incremental
+    mode) for fast edit/build loop. SES 8.22a has no `-build` flag; the
+    only valid action flag is `-rebuild`."""
     result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     cmd = capture_make[0]["cmd"]
-    assert "BUILD_MODE=-build" in cmd
+    assert "BUILD_MODE=" in cmd
     assert "BUILD_MODE=-rebuild" not in cmd
 
 
@@ -192,13 +194,24 @@ def test_fw_clean_invokes_make_clean(runner, fake_repo, fake_segger, capture_mak
     assert "clean" in cmd
 
 
-def test_fw_artifacts_invokes_make_artifacts(
-    runner, fake_repo, fake_segger, capture_make
+def test_fw_artifacts_builds_then_collects_to_user_dir(
+    runner, fake_repo, fake_segger, capture_make, tmp_path
 ):
-    result = runner.invoke(fw_cmd, ["artifacts", "--target", "dotbot-v3"])
+    """`dotbot fw artifacts` no longer runs `make artifacts` (whose path
+    formula is buggy for sandbox and writes to the firmware repo's
+    `artifacts/`). It does a regular build, then copies the produced
+    artifacts to the user-chosen out dir (default `./artifacts/`)."""
+    out = tmp_path / "user-artifacts"
+    result = runner.invoke(
+        fw_cmd, ["artifacts", "--target", "dotbot-v3", "--out", str(out)]
+    )
     assert result.exit_code == 0, result.output
     cmd = capture_make[0]["cmd"]
-    assert "artifacts" in cmd
+    # Builds (no explicit make target), doesn't invoke `make artifacts`.
+    assert "artifacts" not in cmd
+    assert "BUILD_TARGET=dotbot-v3" in cmd
+    # The user-chosen out dir was created.
+    assert out.is_dir()
 
 
 def test_fw_artifacts_print_path_requires_app(runner, fake_repo, fake_segger):
@@ -379,12 +392,15 @@ def test_fw_clean_prints_cleaned_success_line(
 
 
 def test_fw_artifacts_prints_collected_success_line(
-    runner, fake_repo, fake_segger, capture_make
+    runner, fake_repo, fake_segger, capture_make, tmp_path
 ):
-    result = runner.invoke(fw_cmd, ["artifacts", "--target", "dotbot-v3"])
+    result = runner.invoke(
+        fw_cmd,
+        ["artifacts", "--target", "dotbot-v3", "--out", str(tmp_path / "out")],
+    )
     assert result.exit_code == 0, result.output
-    assert "Collecting artifacts" in result.output
-    assert "✓ Artifacts collected" in result.output
+    assert "Building + collecting artifacts" in result.output
+    assert "✓ Collected" in result.output
 
 
 def test_run_make_returns_elapsed_seconds(fake_repo, fake_segger, monkeypatch):

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -662,9 +662,7 @@ def test_resolve_firmware_repo_uses_config_file(tmp_path, monkeypatch, isolated_
     (real_repo / "Makefile").touch()
     # `.as_posix()` keeps backslashes out of the TOML double-quoted
     # string literal on Windows (where they'd be parsed as escapes).
-    _write_config(
-        isolated_home, f'[fw]\nfirmware_repo = "{real_repo.as_posix()}"\n'
-    )
+    _write_config(isolated_home, f'[fw]\nfirmware_repo = "{real_repo.as_posix()}"\n')
     monkeypatch.chdir(tmp_path)  # not inside any workspace
     monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
     assert _fw_helpers.resolve_firmware_repo() == real_repo

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -336,6 +336,40 @@ def test_sandbox_fw_clean_invokes_make_clean(
     assert "clean" in cmd
 
 
+def test_sandbox_fw_artifacts_prepends_sandbox_prefix_in_copy(
+    runner, fake_repo, fake_segger, capture_make, tmp_path, monkeypatch
+):
+    """Sandbox artifacts get a `sandbox-` filename prefix at copy time so
+    they don't collide with bare artifacts in the same `./artifacts/` dir.
+    No upstream project rename needed; the user types `--app dotbot` in
+    the `dotbot swarm fw` namespace without re-stating 'sandbox'."""
+    # Pretend SES wrote a sandbox artifact in the expected location.
+    src_dir = (
+        fake_repo
+        / "apps-sandbox"
+        / "dotbot"
+        / "Output"
+        / "dotbot-v3"
+        / "Release"
+        / "Exe"
+    )
+    src_dir.mkdir(parents=True)
+    (src_dir / "dotbot-dotbot-v3.bin").write_bytes(b"\xde\xad\xbe\xef")
+    monkeypatch.setattr(
+        "dotbot.cli._sandbox_fw.list_projects", lambda target: ["dotbot"]
+    )
+    out = tmp_path / "user-artifacts"
+    result = runner.invoke(
+        sandbox_fw_cmd,
+        ["artifacts", "--target", "dotbot-v3", "--out", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    collected = list(out.iterdir())
+    assert len(collected) == 1
+    # Filename has the prefix; bare equivalent would be dotbot-dotbot-v3.hex.
+    assert collected[0].name == "sandbox-dotbot-dotbot-v3.bin"
+
+
 # ── Output polish: preamble, timing, gated make-line echo ───────────────
 
 

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -170,7 +170,9 @@ def test_fw_build_with_app_appends_project_name(
     monkeypatch.setattr(
         "dotbot.cli.fw.list_projects", lambda target: ["dotbot", "lh2_calibration"]
     )
-    result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v3", "--app", "dotbot"])
+    result = runner.invoke(
+        fw_cmd, ["build", "--target", "dotbot-v3", "--app", "dotbot"]
+    )
     assert result.exit_code == 0, result.output
     cmd = capture_make[0]["cmd"]
     assert cmd[-1] == "dotbot"
@@ -181,7 +183,9 @@ def test_fw_build_rejects_unavailable_project(
 ):
     """Project not in the post-filter list is rejected pre-make."""
     monkeypatch.setattr("dotbot.cli.fw.list_projects", lambda target: ["dotbot"])
-    result = runner.invoke(fw_cmd, ["build", "--target", "dotbot-v1", "--app", "dotbot_gateway"])
+    result = runner.invoke(
+        fw_cmd, ["build", "--target", "dotbot-v1", "--app", "dotbot_gateway"]
+    )
     assert result.exit_code != 0
     assert "not available" in result.output
 
@@ -216,7 +220,9 @@ def test_fw_artifacts_builds_then_collects_to_user_dir(
 
 def test_fw_artifacts_print_path_requires_app(runner, fake_repo, fake_segger):
     """`--print-path` without `--app` exits with a hint."""
-    result = runner.invoke(fw_cmd, ["artifacts", "--target", "dotbot-v3", "--print-path"])
+    result = runner.invoke(
+        fw_cmd, ["artifacts", "--target", "dotbot-v3", "--print-path"]
+    )
     assert result.exit_code != 0
     assert "--app" in result.output
 
@@ -225,7 +231,8 @@ def test_fw_artifacts_print_path_returns_makefile_formula(
     runner, fake_repo, fake_segger
 ):
     result = runner.invoke(
-        fw_cmd, ["artifacts", "--target", "dotbot-v3", "--app", "dotbot", "--print-path"]
+        fw_cmd,
+        ["artifacts", "--target", "dotbot-v3", "--app", "dotbot", "--print-path"],
     )
     assert result.exit_code == 0, result.output
     out = result.output.strip()
@@ -439,17 +446,13 @@ def test_fw_artifacts_prints_collected_success_line(
 
 def test_run_make_returns_elapsed_seconds(fake_repo, fake_segger, monkeypatch):
     """`run_make` must return a float so subcommands can format the timing."""
-    monkeypatch.setattr(
-        "dotbot.cli._fw_helpers.subprocess.call", lambda *a, **kw: 0
-    )
+    monkeypatch.setattr("dotbot.cli._fw_helpers.subprocess.call", lambda *a, **kw: 0)
     elapsed = _fw_helpers.run_make("dotbot-v3", "Release", "dotbot")
     assert isinstance(elapsed, float)
     assert elapsed >= 0
 
 
-def test_sandbox_fw_build_prints_preamble(
-    runner, fake_repo, fake_segger, capture_make
-):
+def test_sandbox_fw_build_prints_preamble(runner, fake_repo, fake_segger, capture_make):
     result = runner.invoke(sandbox_fw_cmd, ["build", "--target", "dotbot-v3"])
     assert result.exit_code == 0, result.output
     assert "Building" in result.output
@@ -637,9 +640,7 @@ def test_resolve_firmware_repo_walks_up_from_cwd(tmp_path, monkeypatch, isolated
     assert _fw_helpers.resolve_firmware_repo() == repo
 
 
-def test_resolve_firmware_repo_uses_config_file(
-    tmp_path, monkeypatch, isolated_home
-):
+def test_resolve_firmware_repo_uses_config_file(tmp_path, monkeypatch, isolated_home):
     """`[fw].firmware_repo` in the config beats workspace walk-up."""
     real_repo = tmp_path / "outside-workspace" / "DotBot-firmware"
     real_repo.mkdir(parents=True)
@@ -738,7 +739,9 @@ def test_targets_match_makefile_list_targets():
             "checkout. Bump the submodule / pull a newer Makefile to enable "
             "this parity guard."
         )
-    makefile_targets = {line.strip() for line in result.stdout.splitlines() if line.strip()}
+    makefile_targets = {
+        line.strip() for line in result.stdout.splitlines() if line.strip()
+    }
     cli_targets = set(_fw_helpers.BARE_TARGETS) | {
         f"sandbox-{b}" for b in _fw_helpers.SANDBOX_BOARDS
     }

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for `dotbot fw` (bare firmware build/clean/targets/artifacts).
+
+These tests stub `subprocess.call` / `subprocess.run` so they don't
+need a SEGGER install or a DotBot-firmware checkout — they verify the
+CLI's argument shape, validations, and the command line passed to
+make, not the actual build.
+"""
+
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from dotbot.cli import _fw_helpers
+from dotbot.cli.fw import cmd as fw_cmd
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_repo(tmp_path, monkeypatch):
+    """Pretend repos/DotBot-firmware exists at a tmp path with a Makefile."""
+    repo = tmp_path / "fake-dotbot-firmware"
+    repo.mkdir()
+    (repo / "Makefile").write_text("# fake\n")
+    monkeypatch.setenv("DOTBOT_FIRMWARE_REPO", str(repo))
+    return repo
+
+
+@pytest.fixture
+def fake_segger(tmp_path, monkeypatch):
+    """Pretend SES is installed at a tmp path with a runnable emBuild."""
+    segger = tmp_path / "fake-segger"
+    (segger / "bin").mkdir(parents=True)
+    embuild = segger / "bin" / "emBuild"
+    embuild.write_text("#!/bin/sh\nexit 0\n")
+    embuild.chmod(0o755)
+    monkeypatch.setenv("SEGGER_DIR", str(segger))
+    return segger
+
+
+@pytest.fixture
+def capture_make(monkeypatch):
+    """Replace `subprocess.call` so we capture the make command line."""
+    calls = []
+
+    def fake_call(cmd, cwd=None, env=None):
+        calls.append({"cmd": cmd, "cwd": cwd, "env": env})
+        return 0
+
+    monkeypatch.setattr("dotbot.cli._fw_helpers.subprocess.call", fake_call)
+    return calls
+
+
+def test_fw_help_lists_real_subcommands(runner):
+    result = runner.invoke(fw_cmd, ["--help"])
+    assert result.exit_code == 0
+    for sub in ("build", "clean", "targets", "artifacts"):
+        assert sub in result.output
+    # Cross-reference to the sandbox path:
+    assert "swarm fw" in result.output
+
+
+def test_fw_targets_lists_bare_targets_one_per_line(runner):
+    result = runner.invoke(fw_cmd, ["targets"])
+    assert result.exit_code == 0
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert "dotbot-v3" in lines
+    assert "sailbot-v1" in lines
+    # No sandbox-* targets under the bare namespace:
+    assert not any(ln.startswith("sandbox-") for ln in lines)
+    # One target per line, no decoration:
+    assert all(ln == ln.strip() for ln in lines)
+
+
+def test_fw_build_rejects_sandbox_target_with_redirect_hint(runner):
+    """Sandbox targets must be rejected with a pointer to `swarm fw`."""
+    result = runner.invoke(fw_cmd, ["build", "sandbox-dotbot-v3"])
+    assert result.exit_code != 0
+    assert "swarm fw build dotbot-v3" in result.output
+
+
+def test_fw_build_rejects_unknown_target_with_suggestion(runner):
+    result = runner.invoke(fw_cmd, ["build", "dotbotv3"])  # missing dash
+    assert result.exit_code != 0
+    assert "dotbot-v3" in result.output  # didyoumean suggestion
+
+
+def test_fw_build_default_target_is_dotbot_v3(
+    runner, fake_repo, fake_segger, capture_make
+):
+    """No-arg build defaults to dotbot-v3 (Geovane's daily target)."""
+    result = runner.invoke(fw_cmd, ["build"])
+    assert result.exit_code == 0, result.output
+    assert len(capture_make) == 1
+    cmd = capture_make[0]["cmd"]
+    assert "BUILD_TARGET=dotbot-v3" in cmd
+    assert "BUILD_CONFIG=Release" in cmd  # default per the plan
+
+
+def test_fw_build_passes_incremental_by_default(
+    runner, fake_repo, fake_segger, capture_make
+):
+    """Default is `BUILD_MODE=-build` (incremental) for fast edit/build loop."""
+    result = runner.invoke(fw_cmd, ["build", "dotbot-v3"])
+    assert result.exit_code == 0, result.output
+    cmd = capture_make[0]["cmd"]
+    assert "BUILD_MODE=-build" in cmd
+    assert "BUILD_MODE=-rebuild" not in cmd
+
+
+def test_fw_build_rebuild_flag_forces_full_rebuild(
+    runner, fake_repo, fake_segger, capture_make
+):
+    result = runner.invoke(fw_cmd, ["build", "dotbot-v3", "--rebuild"])
+    assert result.exit_code == 0, result.output
+    cmd = capture_make[0]["cmd"]
+    assert "BUILD_MODE=-rebuild" in cmd
+
+
+def test_fw_build_quiet_by_default(runner, fake_repo, fake_segger, capture_make):
+    """Default is `QUIET=1` to suppress SES `-verbose -echo` flood."""
+    result = runner.invoke(fw_cmd, ["build", "dotbot-v3"])
+    assert result.exit_code == 0, result.output
+    cmd = capture_make[0]["cmd"]
+    assert "QUIET=1" in cmd
+
+
+def test_fw_build_verbose_drops_quiet(runner, fake_repo, fake_segger, capture_make):
+    result = runner.invoke(fw_cmd, ["build", "dotbot-v3", "-v"])
+    assert result.exit_code == 0, result.output
+    cmd = capture_make[0]["cmd"]
+    assert "QUIET=1" not in cmd
+
+
+def test_fw_build_with_app_appends_project_name(
+    runner, fake_repo, fake_segger, capture_make, monkeypatch
+):
+    """`--app NAME` appends the project so make builds only that one."""
+    monkeypatch.setattr(
+        "dotbot.cli.fw.list_projects", lambda target: ["dotbot", "lh2_calibration"]
+    )
+    result = runner.invoke(fw_cmd, ["build", "dotbot-v3", "--app", "dotbot"])
+    assert result.exit_code == 0, result.output
+    cmd = capture_make[0]["cmd"]
+    assert cmd[-1] == "dotbot"
+
+
+def test_fw_build_rejects_unavailable_project(
+    runner, fake_repo, fake_segger, monkeypatch
+):
+    """Project not in the post-filter list is rejected pre-make."""
+    monkeypatch.setattr("dotbot.cli.fw.list_projects", lambda target: ["dotbot"])
+    result = runner.invoke(fw_cmd, ["build", "dotbot-v1", "--app", "dotbot_gateway"])
+    assert result.exit_code != 0
+    assert "not available" in result.output
+
+
+def test_fw_clean_invokes_make_clean(runner, fake_repo, fake_segger, capture_make):
+    result = runner.invoke(fw_cmd, ["clean", "dotbot-v3"])
+    assert result.exit_code == 0, result.output
+    cmd = capture_make[0]["cmd"]
+    assert "BUILD_TARGET=dotbot-v3" in cmd
+    assert "clean" in cmd
+
+
+def test_fw_artifacts_invokes_make_artifacts(
+    runner, fake_repo, fake_segger, capture_make
+):
+    result = runner.invoke(fw_cmd, ["artifacts", "dotbot-v3"])
+    assert result.exit_code == 0, result.output
+    cmd = capture_make[0]["cmd"]
+    assert "artifacts" in cmd
+
+
+def test_fw_artifacts_print_path_requires_app(runner, fake_repo, fake_segger):
+    """`--print-path` without `--app` exits with a hint."""
+    result = runner.invoke(fw_cmd, ["artifacts", "dotbot-v3", "--print-path"])
+    assert result.exit_code != 0
+    assert "--app" in result.output
+
+
+def test_fw_artifacts_print_path_returns_makefile_formula(
+    runner, fake_repo, fake_segger
+):
+    result = runner.invoke(
+        fw_cmd, ["artifacts", "dotbot-v3", "--app", "dotbot", "--print-path"]
+    )
+    assert result.exit_code == 0, result.output
+    out = result.output.strip()
+    assert out.endswith("apps/dotbot/Output/dotbot-v3/Release/Exe/dotbot-dotbot-v3.hex")
+
+
+def test_fw_new_still_not_implemented(runner):
+    """`new` is deferred to a separate templates plan."""
+    result = runner.invoke(fw_cmd, ["new", "my-experiment"])
+    assert result.exit_code == 2
+    assert "not implemented" in result.output.lower()
+
+
+def test_fw_flash_still_not_implemented(runner):
+    """`flash` is deferred; SES + J-Link cover the bare path today."""
+    result = runner.invoke(fw_cmd, ["flash", "/tmp/dummy.hex"])
+    assert result.exit_code == 2
+    assert "not implemented" in result.output.lower()
+
+
+# ── Helper-level tests ──────────────────────────────────────────────────
+
+
+def test_resolve_segger_dir_uses_env_first(tmp_path, monkeypatch):
+    monkeypatch.setenv("SEGGER_DIR", str(tmp_path))
+    assert _fw_helpers.resolve_segger_dir() == tmp_path
+
+
+def test_resolve_segger_dir_errors_when_unset_on_linux(monkeypatch):
+    monkeypatch.delenv("SEGGER_DIR", raising=False)
+    monkeypatch.setattr("dotbot.cli._fw_helpers.sys.platform", "linux")
+    with pytest.raises(click.ClickException) as excinfo:
+        _fw_helpers.resolve_segger_dir()
+    assert "SEGGER_DIR" in str(excinfo.value)
+
+
+def test_resolve_firmware_repo_walks_up_from_cwd(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    repo = workspace / "repos" / "DotBot-firmware"
+    repo.mkdir(parents=True)
+    (repo / "Makefile").touch()
+    inner = workspace / "deep" / "subdir"
+    inner.mkdir(parents=True)
+    monkeypatch.chdir(inner)
+    monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
+    assert _fw_helpers.resolve_firmware_repo() == repo
+
+
+def test_resolve_firmware_repo_errors_outside_workspace(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
+    with pytest.raises(click.ClickException):
+        _fw_helpers.resolve_firmware_repo()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ path = "utils/hooks/sdist.py"
 
 [project]
 name = "pydotbot"
-version = "0.27.0"
+version = "0.28.0rc1"
 authors = [
     { name="Alexandre Abadie", email="alexandre.abadie@inria.fr" },
     { name="Theo Akbas", email="theo.akbas@inria.fr" },
@@ -30,6 +30,7 @@ authors = [
     { name="Said Alvarado-Marin", email="said-alexander.alvarado-marin@inria.fr" },
     { name="Mališa Vučinić", email="malisa.vucinic@inria.fr" },
     { name="Diego Badillo", email="diego.badillo@sansano.usm.cl" },
+    { name="Geovane Fedrecheski", email="geovane.fedrecheski@inria.fr" },
 ]
 dependencies = [
     "click          >= 8.1.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,13 +81,19 @@ dotbot-joystick = "dotbot.joystick:main"
 # in dotbot-python — the names belonged to the standalone PyPI
 # packages, which keep their own scripts during their own
 # deprecation cycle. Users coming from those packages use
-# `dotbot testbed provision …` and `dotbot calibrate …`.
+# `dotbot swarm provision …` and `dotbot calibrate …`.
 
 [project.optional-dependencies]
 # Optional subcommand backends. Keep the core install lean; opt in to
 # the bits you actually use.
-testbed = [
+swarm = [
     "swarmit          >= 0.6.0",
+]
+# Deprecated alias for `[swarm]` (was the original extras name when
+# the subcommand was called `dotbot testbed`). Drop one release after
+# the rename ships.
+testbed = [
+    "pydotbot[swarm]",
 ]
 provision = [
     "intelhex         >= 2.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,12 +89,6 @@ dotbot-joystick = "dotbot.joystick:main"
 swarm = [
     "swarmit          >= 0.6.0",
 ]
-# Deprecated alias for `[swarm]` (was the original extras name when
-# the subcommand was called `dotbot testbed`). Drop one release after
-# the rename ships.
-testbed = [
-    "pydotbot[swarm]",
-]
 provision = [
     "intelhex         >= 2.3.0",
 ]


### PR DESCRIPTION
Replaces the `dotbot fw` mock surface (was printing NOT IMPLEMENTED)
with a real SES + emBuild wrapper, adds a sibling `dotbot make` escape
hatch, and renames `dotbot testbed` → `dotbot swarm`.

Soft-depends on DotBots/DotBot-firmware#412 (Makefile additions:
`BUILD_MODE` knob and `list-targets` rule). The CLI tolerates an
unpatched Makefile — it just loses incremental builds and the parity
test self-skips.

## Why bundle the rename

The new sandbox-firmware build subcommand had to live somewhere, and
the two options were `dotbot testbed fw build` or `dotbot swarm fw
build`. Shipping it under the old name and renaming a release later
would be pure churn. Bundling means we document the new surface only
once.

No deprecated alias kept — the rename hasn't shipped on any PyPI
release yet (the prior `dotbot testbed` form only ever existed on
`develop`), so there's no compatibility surface to preserve. `dotbot
testbed <anything>` now errors with Click's standard "no such command"
message.

## `dotbot fw` design — namespace split, not a flag

| user-facing                          | what it builds                                                            |
|--------------------------------------|---------------------------------------------------------------------------|
| `dotbot fw build <target>`           | bare apps from DotBot-firmware's `apps/` (talk directly to the radio)     |
| `dotbot swarm fw build <board>`      | sandbox apps from `apps-sandbox/` (TrustZone NS, OTA-flashed via swarmit) |

Discriminating by namespace (rather than a `--bare/--swarmit` flag, or
a `dotbot-bare` / `dotbot-sandbox` pseudo-target) scales naturally as
more firmware realms come in (mari node/gateway, swarmit S-side). Each
realm gets its own group; `--help` surfaces stay legible.

`dotbot fw build` is deliberately opinionated: positional `TARGET`,
`--app NAME`, `--config Debug|Release`, `--rebuild`, `-v`. Anything
else (`PACKAGES_DIR_OPT`, `DOCKER` overrides, `make doc`, format
checks, ...) is intentionally not modelled — the sibling `dotbot make`
subcommand forwards arbitrary args to make in the firmware repo with
workspace-resolved `SEGGER_DIR`. `dotbot fw --help` ends with
*"Need a Makefile knob not covered by these flags? Use
`dotbot make --help`."* The CLI says its own limits out loud.

## Per-user config (no more pinned SES version)

SEGGER_DIR and the path to the DotBot-firmware checkout can now live
in `~/.dotbot/config.toml` — the same dir the controller already uses
for calibration state:

```toml
[fw]
segger_dir = "/Applications/SEGGER/SEGGER Embedded Studio 8.30"
firmware_repo = "/Users/me/Developer/dotbot-testbed/repos/DotBot-firmware"
```

Resolution order (first match wins):

- SEGGER_DIR: env var → `[fw].segger_dir` → glob
  `/Applications/SEGGER/SEGGER Embedded Studio*` on macOS (latest
  sort-order pick).
- firmware repo: env var → `[fw].firmware_repo` → walk up from CWD
  looking for `repos/DotBot-firmware/Makefile`.

Replaces the previously-hardcoded `8.22a` macOS path so SES upgrades
don't silently break the CLI, and lets the CLI work from anywhere on
the machine (not just from inside a workspace clone).

## Daily-loop wins

- Defaults to incremental builds (passes `BUILD_MODE=-build` to the
  Makefile) — edit one .c file and rebuild in ~5–10s instead of ~90s.
  Requires the Makefile patch in DotBot-firmware#412.
- Defaults to `QUIET=1` to suppress SES's verbose/echo flood; the
  per-project banners still come through.
- Validates `TARGET` / project name / sandbox-prefix pre-make, so a
  typo (`dotbotv3`) surfaces in <1s with a `Did you mean 'dotbot-v3'?`
  hint instead of an opaque SES error 30s in.
- Preamble + ✓ success line with timing:
  `Building dotbot for dotbot-v3 (Release, incremental)... ✓ Built
  dotbot-v3 in 8.3s`. For `--app NAME` builds, also echoes the
  artifact path on its own stdout line so pipelines work:
  `dotbot fw build dotbot-v3 --app dotbot | tail -1 | xargs nrfjprog ...`

## Out of scope

- `dotbot fw flash` and `dotbot fw new` stay as `NOT IMPLEMENTED` —
  templates and cabled-flash toolchain pickling each warrant their
  own design pass. SES + J-Link covers the cabled-flash path today;
  `dotbot swarm flash` (existing `swarmit flash`) covers OTA.
- Mari firmware builds and the swarmit S-side bootloader/netcore.
  Different Makefile shapes; future work. Use the per-repo Makefiles
  directly until then.
- CMake migration. Stays postponed; the CLI surface won't change when
  it lands — only the helper switches from `make` to `cmake`.

## Validation

74 unit tests pass — 29 for `dotbot fw`, 8 for the sandbox subgroup,
17 for output polish + the escape hatch, 11 for config-file + path
resolution, plus a parity guard that asserts
`set(BARE_TARGETS) | {sandbox-<b>} == set(make list-targets)` against
the real DotBot-firmware repo (self-skips if `list-targets` rule isn't
present, so existing checkouts don't false-fail).

Live-tested end-to-end:
- `dotbot --help` shows `swarm`, `fw`, `make`; no `testbed`.
- `dotbot testbed --help` errors with Click's "No such command 'testbed'".
- `dotbot fw clean dotbot-v3` invokes `make ... clean` → `emBuild ...
  -clean`, prints the preamble and ✓ success line with timing.
- `dotbot fw artifacts dotbot-v3 --app dotbot --print-path` works from
  outside the workspace when `~/.dotbot/config.toml` provides
  `[fw].firmware_repo`.
- `dotbot make list-targets` forwards to the new Make rule.
- `dotbot fw build sandbox-dotbot-v3` rejects with
  *"Use `dotbot swarm fw build dotbot-v3` instead."*
- `dotbot fw build dotbotv3` rejects with *"Did you mean 'dotbot-v3'?"*