### PR TITLE
pyproject: bump to 0.29.0rc1 + improve firmware-repo discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ path = "utils/hooks/sdist.py"
 
 [project]
 name = "pydotbot"
-version = "0.28.0rc1"
+version = "0.29.0rc1"
 authors = [
     { name="Alexandre Abadie", email="alexandre.abadie@inria.fr" },
     { name="Theo Akbas", email="theo.akbas@inria.fr" },


### PR DESCRIPTION
Two small commits before the next RC publishes:

## 1. Bump version to 0.29.0rc1 (`27ddb4a`)

0.28.0 was already on PyPI when the 0.28.0rc1 tag was pushed earlier
today, so under PEP 440 the RC sorts strictly BELOW the existing
0.28.0 final — `pip install pydotbot` and even `pip install --pre
pydotbot` keep the 0.28.0 stable. The CI publish for v0.28.0rc1 was
cancelled before PyPI upload, so nothing landed there; the upstream
v0.28.0rc1 tag is harmless cruft that can be deleted at leisure.

Bumping to 0.29.0rc1 so the next tag-push produces a release
candidate that's actually the highest pre-release version on PyPI.

## 2. Improve `DotBot-firmware` discovery (`2ac2045`)

Walk-up previously only checked `<parent>/repos/DotBot-firmware/` —
fine inside the workspace clone, but misses the common new-user
shape:

```bash
cd ~/Developer
git clone https://github.com/DotBots/DotBot-firmware.git
cd ~/Developer
dotbot fw targets   # used to error; now succeeds
```

Now also tries `<cwd>/DotBot-firmware/` (sibling clone) and detects
the case where CWD is inside the repo itself (any parent named
`DotBot-firmware` with a Makefile is the root). The error message
when nothing matches now lists all three layouts and the three
escape hatches (clone-into-cwd / env var / config file).