### PR TITLE
dotbot/cli/_fw_helpers: simplify firmware-repo discovery (env or CWD-sibling)

### DIFF
--- a/dotbot/cli/_fw_helpers.py
+++ b/dotbot/cli/_fw_helpers.py
@@ -12,22 +12,21 @@ resolution, and the make invocation contract stay in one place.
 
 ## Configuration
 
-`SEGGER_DIR` and the path to the DotBot-firmware checkout can be set
-in `~/.dotbot/config.toml` so they don't need to be passed via env
-on every shell:
+`SEGGER_DIR` can be persisted in `~/.dotbot/config.toml` so it doesn't
+have to ride in every shell:
 
 ```toml
 [fw]
 segger_dir = "/Applications/SEGGER/SEGGER Embedded Studio 8.30"
-firmware_repo = "/Users/me/Developer/dotbot-testbed/repos/DotBot-firmware"
 ```
 
 Resolution order (first match wins):
-- `SEGGER_DIR` env var ↦ `[fw].segger_dir` in config ↦ glob
-  `/Applications/SEGGER/SEGGER Embedded Studio*` on macOS (latest
-  sort-order pick).
-- `DOTBOT_FIRMWARE_REPO` env var ↦ `[fw].firmware_repo` in config ↦
-  walk up from CWD looking for `repos/DotBot-firmware/Makefile`.
+- SEGGER: `SEGGER_DIR` env var → `[fw].segger_dir` in config → glob
+  `/Applications/SEGGER/SEGGER Embedded Studio*` on macOS.
+- firmware repo: `DOTBOT_FIRMWARE_REPO` env var → `<cwd>/DotBot-firmware/`.
+  Deliberately minimal — no parent walk-up, no `repos/` heuristics, no
+  config-file precedence. Either you `cd` to where your clone is, or
+  you point at it explicitly.
 """
 
 import difflib
@@ -143,7 +142,13 @@ def resolve_segger_dir() -> Path:
 
 
 def resolve_firmware_repo() -> Path:
-    """DOTBOT_FIRMWARE_REPO env → config → workspace walk-up → error."""
+    """DOTBOT_FIRMWARE_REPO env → ./DotBot-firmware/ → error.
+
+    Deliberately minimal — no parent walk-up, no `repos/` heuristics,
+    no config-file precedence. Either the env var points somewhere
+    valid, or the user `cd`'d to the directory that contains a
+    sibling `DotBot-firmware/` clone.
+    """
     env = os.environ.get("DOTBOT_FIRMWARE_REPO")
     if env:
         candidate = Path(env)
@@ -152,40 +157,13 @@ def resolve_firmware_repo() -> Path:
         raise click.ClickException(
             f"DOTBOT_FIRMWARE_REPO={env!r} does not contain a Makefile."
         )
-    cfg = _config_fw_value("firmware_repo")
-    if cfg:
-        candidate = Path(cfg)
-        if (candidate / "Makefile").is_file():
-            return candidate
-        raise click.ClickException(
-            f"[fw].firmware_repo={cfg!r} in {_CONFIG_PATH} does not contain "
-            f"a Makefile."
-        )
-    cwd = Path.cwd().resolve()
-    for parent in (cwd, *cwd.parents):
-        # Workspace layout: <somewhere>/repos/DotBot-firmware/
-        candidate = parent / "repos" / "DotBot-firmware"
-        if (candidate / "Makefile").is_file():
-            return candidate
-        # Sibling clone: <cwd>/DotBot-firmware/
-        candidate = parent / "DotBot-firmware"
-        if (candidate / "Makefile").is_file():
-            return candidate
-        # Inside the repo itself (or one of its subdirs): the parent named
-        # `DotBot-firmware` with a Makefile is the root.
-        if parent.name == "DotBot-firmware" and (parent / "Makefile").is_file():
-            return parent
+    candidate = Path.cwd() / "DotBot-firmware"
+    if (candidate / "Makefile").is_file():
+        return candidate
     raise click.ClickException(
-        "Could not locate DotBot-firmware. Tried:\n"
-        "  - <cwd>/DotBot-firmware/\n"
-        "  - <cwd>/repos/DotBot-firmware/\n"
-        "  - walking up the parent chain\n"
-        "Fix one of:\n"
-        "  - clone DotBot-firmware into the current directory, or\n"
-        "  - export DOTBOT_FIRMWARE_REPO=/path/to/DotBot-firmware, or\n"
-        "  - add to ~/.dotbot/config.toml:\n"
-        "      [fw]\n"
-        '      firmware_repo = "/path/to/DotBot-firmware"'
+        "Could not locate DotBot-firmware. Either:\n"
+        "  - `cd` to the directory containing your DotBot-firmware clone, or\n"
+        "  - export DOTBOT_FIRMWARE_REPO=/path/to/DotBot-firmware"
     )
 
 

--- a/dotbot/cli/_fw_helpers.py
+++ b/dotbot/cli/_fw_helpers.py
@@ -163,16 +163,29 @@ def resolve_firmware_repo() -> Path:
         )
     cwd = Path.cwd().resolve()
     for parent in (cwd, *cwd.parents):
+        # Workspace layout: <somewhere>/repos/DotBot-firmware/
         candidate = parent / "repos" / "DotBot-firmware"
         if (candidate / "Makefile").is_file():
             return candidate
+        # Sibling clone: <cwd>/DotBot-firmware/
+        candidate = parent / "DotBot-firmware"
+        if (candidate / "Makefile").is_file():
+            return candidate
+        # Inside the repo itself (or one of its subdirs): the parent named
+        # `DotBot-firmware` with a Makefile is the root.
+        if parent.name == "DotBot-firmware" and (parent / "Makefile").is_file():
+            return parent
     raise click.ClickException(
-        "Could not locate DotBot-firmware.\n"
-        "Either run from inside a workspace that has "
-        "`repos/DotBot-firmware`, export DOTBOT_FIRMWARE_REPO, or add to "
-        "~/.dotbot/config.toml:\n"
-        "  [fw]\n"
-        '  firmware_repo = "/path/to/DotBot-firmware"'
+        "Could not locate DotBot-firmware. Tried:\n"
+        "  - <cwd>/DotBot-firmware/\n"
+        "  - <cwd>/repos/DotBot-firmware/\n"
+        "  - walking up the parent chain\n"
+        "Fix one of:\n"
+        "  - clone DotBot-firmware into the current directory, or\n"
+        "  - export DOTBOT_FIRMWARE_REPO=/path/to/DotBot-firmware, or\n"
+        "  - add to ~/.dotbot/config.toml:\n"
+        "      [fw]\n"
+        '      firmware_repo = "/path/to/DotBot-firmware"'
     )
 
 

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -643,51 +643,8 @@ def test_resolve_segger_dir_errors_when_nothing_found(monkeypatch, isolated_home
     assert "~/.dotbot/config.toml" in msg
 
 
-def test_resolve_firmware_repo_walks_up_from_cwd(tmp_path, monkeypatch, isolated_home):
-    workspace = tmp_path / "ws"
-    repo = workspace / "repos" / "DotBot-firmware"
-    repo.mkdir(parents=True)
-    (repo / "Makefile").touch()
-    inner = workspace / "deep" / "subdir"
-    inner.mkdir(parents=True)
-    monkeypatch.chdir(inner)
-    monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
-    assert _fw_helpers.resolve_firmware_repo() == repo
-
-
-def test_resolve_firmware_repo_uses_config_file(tmp_path, monkeypatch, isolated_home):
-    """`[fw].firmware_repo` in the config beats workspace walk-up."""
-    real_repo = tmp_path / "outside-workspace" / "DotBot-firmware"
-    real_repo.mkdir(parents=True)
-    (real_repo / "Makefile").touch()
-    # `.as_posix()` keeps backslashes out of the TOML double-quoted
-    # string literal on Windows (where they'd be parsed as escapes).
-    _write_config(isolated_home, f'[fw]\nfirmware_repo = "{real_repo.as_posix()}"\n')
-    monkeypatch.chdir(tmp_path)  # not inside any workspace
-    monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
-    assert _fw_helpers.resolve_firmware_repo() == real_repo
-
-
-def test_resolve_firmware_repo_config_pointing_at_no_makefile_errors(
-    tmp_path, monkeypatch, isolated_home
-):
-    """If the config points at a bad path, fail loudly — don't silently fall
-    through to the workspace walk-up."""
-    bad = tmp_path / "no-makefile-here"
-    bad.mkdir()
-    _write_config(isolated_home, f'[fw]\nfirmware_repo = "{bad.as_posix()}"\n')
-    monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
-    with pytest.raises(click.ClickException) as excinfo:
-        _fw_helpers.resolve_firmware_repo()
-    assert "firmware_repo" in str(excinfo.value)
-
-
-def test_resolve_firmware_repo_finds_sibling_clone(
-    tmp_path, monkeypatch, isolated_home
-):
-    """Common new-user flow: clone DotBot-firmware into the current
-    directory (`./DotBot-firmware/`), then run `dotbot fw ...` from
-    that same directory. No `repos/` layer."""
+def test_resolve_firmware_repo_finds_sibling_clone(tmp_path, monkeypatch):
+    """The one default lookup path: `<cwd>/DotBot-firmware/Makefile`."""
     repo = tmp_path / "DotBot-firmware"
     repo.mkdir()
     (repo / "Makefile").touch()
@@ -696,33 +653,42 @@ def test_resolve_firmware_repo_finds_sibling_clone(
     assert _fw_helpers.resolve_firmware_repo() == repo
 
 
-def test_resolve_firmware_repo_finds_when_cwd_inside_the_repo(
-    tmp_path, monkeypatch, isolated_home
-):
-    """Inside the repo itself (e.g. `cd DotBot-firmware/apps/`), walking up
-    finds the dir named `DotBot-firmware` with a Makefile."""
-    repo = tmp_path / "DotBot-firmware"
-    inner = repo / "apps" / "dotbot"
-    inner.mkdir(parents=True)
-    (repo / "Makefile").touch()
-    monkeypatch.chdir(inner)
-    monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
-    assert _fw_helpers.resolve_firmware_repo() == repo
+def test_resolve_firmware_repo_env_var_wins(tmp_path, monkeypatch):
+    """Env var overrides the CWD-sibling default."""
+    sibling = tmp_path / "DotBot-firmware"
+    sibling.mkdir()
+    (sibling / "Makefile").touch()
+    elsewhere = tmp_path / "elsewhere" / "DotBot-firmware"
+    elsewhere.mkdir(parents=True)
+    (elsewhere / "Makefile").touch()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DOTBOT_FIRMWARE_REPO", str(elsewhere))
+    assert _fw_helpers.resolve_firmware_repo() == elsewhere
 
 
-def test_resolve_firmware_repo_errors_outside_workspace(
-    tmp_path, monkeypatch, isolated_home
-):
+def test_resolve_firmware_repo_errors_when_nothing_found(tmp_path, monkeypatch):
+    """No env var, no `<cwd>/DotBot-firmware/` → clear error with both
+    escape hatches in the message."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
     with pytest.raises(click.ClickException) as excinfo:
         _fw_helpers.resolve_firmware_repo()
     msg = str(excinfo.value)
-    # All escape hatches surfaced.
     assert "DOTBOT_FIRMWARE_REPO" in msg
-    assert "~/.dotbot/config.toml" in msg
-    # And the sibling-clone hint.
-    assert "clone DotBot-firmware" in msg
+    assert "cd" in msg  # the "cd to the directory containing your clone" hint
+
+
+def test_resolve_firmware_repo_env_var_pointing_at_no_makefile_errors(
+    tmp_path, monkeypatch
+):
+    """Bad env-var path fails loudly rather than silently falling back."""
+    bad = tmp_path / "no-makefile-here"
+    bad.mkdir()
+    monkeypatch.setenv("DOTBOT_FIRMWARE_REPO", str(bad))
+    with pytest.raises(click.ClickException) as excinfo:
+        _fw_helpers.resolve_firmware_repo()
+    assert "DOTBOT_FIRMWARE_REPO" in str(excinfo.value)
+    assert "Makefile" in str(excinfo.value)
 
 
 def test_malformed_config_raises_with_path(monkeypatch, isolated_home):

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -682,6 +682,34 @@ def test_resolve_firmware_repo_config_pointing_at_no_makefile_errors(
     assert "firmware_repo" in str(excinfo.value)
 
 
+def test_resolve_firmware_repo_finds_sibling_clone(
+    tmp_path, monkeypatch, isolated_home
+):
+    """Common new-user flow: clone DotBot-firmware into the current
+    directory (`./DotBot-firmware/`), then run `dotbot fw ...` from
+    that same directory. No `repos/` layer."""
+    repo = tmp_path / "DotBot-firmware"
+    repo.mkdir()
+    (repo / "Makefile").touch()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
+    assert _fw_helpers.resolve_firmware_repo() == repo
+
+
+def test_resolve_firmware_repo_finds_when_cwd_inside_the_repo(
+    tmp_path, monkeypatch, isolated_home
+):
+    """Inside the repo itself (e.g. `cd DotBot-firmware/apps/`), walking up
+    finds the dir named `DotBot-firmware` with a Makefile."""
+    repo = tmp_path / "DotBot-firmware"
+    inner = repo / "apps" / "dotbot"
+    inner.mkdir(parents=True)
+    (repo / "Makefile").touch()
+    monkeypatch.chdir(inner)
+    monkeypatch.delenv("DOTBOT_FIRMWARE_REPO", raising=False)
+    assert _fw_helpers.resolve_firmware_repo() == repo
+
+
 def test_resolve_firmware_repo_errors_outside_workspace(
     tmp_path, monkeypatch, isolated_home
 ):
@@ -690,9 +718,11 @@ def test_resolve_firmware_repo_errors_outside_workspace(
     with pytest.raises(click.ClickException) as excinfo:
         _fw_helpers.resolve_firmware_repo()
     msg = str(excinfo.value)
-    # Both escape hatches surfaced.
+    # All escape hatches surfaced.
     assert "DOTBOT_FIRMWARE_REPO" in msg
     assert "~/.dotbot/config.toml" in msg
+    # And the sibling-clone hint.
+    assert "clone DotBot-firmware" in msg
 
 
 def test_malformed_config_raises_with_path(monkeypatch, isolated_home):


### PR DESCRIPTION
The first attempt at this fix added a smarter discovery — walk up the
parent chain, look for `<somewhere>/repos/DotBot-firmware/` (workspace
layout), detect "cwd is inside the repo." Reviewing the result, the
heuristic stack does more harm than good: it picks up unexpected
directories, hides the user's actual setup, and makes the failure
mode "why did it pick THAT clone" instead of "where is it."

Replaced with two paths, no more:

1. `DOTBOT_FIRMWARE_REPO` env var if set.
2. `<cwd>/DotBot-firmware/` if it has a Makefile.

Otherwise: clear error pointing at those two options.

The `[fw].firmware_repo` config-file precedence is dropped at the
same time (the SEGGER_DIR config still works; that's an install-path
question that genuinely benefits from persistence, vs. firmware-repo
location which the user just `cd`s to).

## Behaviour matrix

| Where you are | What you set | What happens |
|---|---|---|
| `cd ~/somewhere` with `./DotBot-firmware/` | nothing | uses `./DotBot-firmware/` |
| anywhere | `export DOTBOT_FIRMWARE_REPO=…` | uses the env path |
| anywhere, env points at a no-Makefile dir | env set | clean error: "DOTBOT_FIRMWARE_REPO=… does not contain a Makefile" |
| `cd /tmp`, no env, no sibling | nothing | clean error: "Either: cd to the directory containing your DotBot-firmware clone, or export DOTBOT_FIRMWARE_REPO=…" |

## Tests

53 unit tests pass. Four cover `resolve_firmware_repo()`:
- `test_resolve_firmware_repo_finds_sibling_clone`
- `test_resolve_firmware_repo_env_var_wins`
- `test_resolve_firmware_repo_errors_when_nothing_found`
- `test_resolve_firmware_repo_env_var_pointing_at_no_makefile_errors`

## Net change

`-107 / +51` — discovery is now ~10 lines of code.