### PR TITLE
dotbot/cli: collapse controller transport flags into a single --conn

### DIFF
--- a/dotbot/adapter.py
+++ b/dotbot/adapter.py
@@ -43,7 +43,14 @@ class GatewayAdapterBase(ABC):
 
 
 class SerialAdapter(GatewayAdapterBase):
-    """Class used to interface with the serial port."""
+    """Raw (non-Mari) serial gateway interface.
+
+    Deprecated: the `--conn` CLI no longer selects this — a device-path
+    connection maps to the Mari `edge` adapter, since bare DotBot apps now
+    emit Mari-shaped frames and the gateway speaks Mari-shaped UART
+    packets (so the edge adapter handles both sandbox and bare). Kept for
+    now as no CLI path constructs it; likely removed in a future cleanup.
+    """
 
     def __init__(
         self,

--- a/dotbot/adapter.py
+++ b/dotbot/adapter.py
@@ -159,8 +159,8 @@ class MarilibCloudAdapter(GatewayAdapterBase):
         port: int,
         use_tls: bool,
         network_id: int,
-        username: str = None,
-        password: str = None,
+        username: str | None = None,
+        password: str | None = None,
     ):
         self.host = host
         self.port = port

--- a/dotbot/adapter.py
+++ b/dotbot/adapter.py
@@ -242,6 +242,10 @@ class MarilibCloudAdapter(GatewayAdapterBase):
 class SimulatorAdapterBase(GatewayAdapterBase):
     """Base class used to interface with the simulator."""
 
+    # Assigned in start(); stays None if start() failed before the
+    # simulator was constructed, so close() can no-op instead of raising.
+    simulator = None
+
     @abstractmethod
     def create_simulator(self, _byte_received: callable):
         """Create the simulator instance."""
@@ -264,6 +268,8 @@ class SimulatorAdapterBase(GatewayAdapterBase):
             self.on_frame_received(frame)
 
     def close(self):
+        if self.simulator is None:
+            return
         LOGGER.info("Disconnect from simulator...")
         self.simulator.stop()
 

--- a/dotbot/adapter.py
+++ b/dotbot/adapter.py
@@ -159,11 +159,15 @@ class MarilibCloudAdapter(GatewayAdapterBase):
         port: int,
         use_tls: bool,
         network_id: int,
+        username: str = None,
+        password: str = None,
     ):
         self.host = host
         self.port = port
         self.use_tls = use_tls
         self.network_id = network_id
+        self.username = username
+        self.password = password
 
     async def start(self, on_frame_received: callable):
         self.on_frame_received = on_frame_received
@@ -189,10 +193,24 @@ class MarilibCloudAdapter(GatewayAdapterBase):
                     queue.put_nowait, Frame(header=event_data.header, packet=packet)
                 )
 
+        # Broker credentials (from DOTBOT_MQTT_USER / DOTBOT_MQTT_PASS,
+        # threaded down by controller_app) are passed only when set.
+        # NOTE: requires the marilib companion that adds username/password
+        # to MarilibMQTTAdapter; until that lands, set credentials are a
+        # no-op (anonymous connect), which matches today's behaviour.
+        mqtt_kwargs = {}
+        if self.username is not None:
+            mqtt_kwargs["username"] = self.username
+        if self.password is not None:
+            mqtt_kwargs["password"] = self.password
         self.mari = MarilibCloud(
             _on_mari_event,
             MarilibMQTTAdapter(
-                self.host, self.port, use_tls=self.use_tls, is_edge=False
+                self.host,
+                self.port,
+                use_tls=self.use_tls,
+                is_edge=False,
+                **mqtt_kwargs,
             ),
             self.network_id,
         )

--- a/dotbot/cli/_conn.py
+++ b/dotbot/cli/_conn.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Parse a `--conn` connection string into a typed result.
+
+`dotbot controller --conn CONNECTION` takes one discriminated
+connection string whose *form* selects the kind of connection - the
+`git remote` / `docker -H` / MAVSDK `add_any_connection()` pattern:
+
+| value                                  | kind        |
+|----------------------------------------|-------------|
+| `mqtts://host:port` / `mqtt://host:port` | `mqtt`    |
+| `/dev/ttyACM0`, `/dev/tty.usbmodem…`, `COM3` | `serial` |
+| `simulator` / `sim`                    | `simulator` |
+
+Keeping this a pure function (no Click, no I/O) so it's exhaustively
+unit-testable without hardware.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class ConnectionSpec:
+    """Result of parsing a `--conn` value.
+
+    `kind` is one of "mqtt" | "serial" | "simulator". The other fields
+    are populated per kind:
+      - mqtt:      host, port, use_tls
+      - serial:    serial_port
+      - simulator: (no extra fields; robot type is a separate flag)
+    """
+
+    kind: str
+    host: Optional[str] = None
+    port: Optional[int] = None
+    use_tls: bool = False
+    serial_port: Optional[str] = None
+
+
+class ConnError(ValueError):
+    """Raised when a `--conn` value can't be parsed."""
+
+
+# Accepted spellings for the simulator (documented: `simulator`).
+_SIMULATOR_VALUES = {"simulator", "sim"}
+
+
+def parse_connection(value: str) -> ConnectionSpec:
+    """Parse a `--conn` string. Raises ConnError on a malformed value."""
+    if not value:
+        raise ConnError("empty connection string")
+
+    lowered = value.strip().lower()
+
+    # Simulator — a bare keyword.
+    if lowered in _SIMULATOR_VALUES:
+        return ConnectionSpec(kind="simulator")
+
+    # MQTT — discriminated by the mqtt:// / mqtts:// scheme.
+    if lowered.startswith(("mqtt://", "mqtts://")):
+        parsed = urlparse(value)
+        use_tls = parsed.scheme == "mqtts"
+        host = parsed.hostname
+        port = parsed.port
+        if not host:
+            raise ConnError(f"no host in MQTT connection string: {value!r}")
+        if port is None:
+            # Sensible MQTT defaults: 8883 for TLS, 1883 for plain.
+            port = 8883 if use_tls else 1883
+        return ConnectionSpec(kind="mqtt", host=host, port=port, use_tls=use_tls)
+
+    # Anything else that has a `scheme://` we don't recognize is an error,
+    # rather than being silently treated as a device path.
+    if "://" in value:
+        raise ConnError(
+            f"unrecognized connection scheme in {value!r} "
+            "(expected mqtt:// or mqtts://, a device path, or 'simulator')"
+        )
+
+    # Otherwise: treat as a serial device path (`/dev/ttyACM0`, `COM3`, …).
+    # Plain path (no `serial://` scheme) so shell tab-completion works.
+    return ConnectionSpec(kind="serial", serial_port=value)
+
+
+def needs_swarm_id(parsed: ConnectionSpec) -> bool:
+    """True if this connection requires `--swarm-id`.
+
+    Only MQTT does: the broker carries traffic for many swarms, and the
+    swarm id selects the topic namespace. A serial gateway already
+    belongs to one swarm; a simulator has none.
+    """
+    return parsed.kind == "mqtt"

--- a/dotbot/cli/_conn.py
+++ b/dotbot/cli/_conn.py
@@ -19,7 +19,8 @@ unit-testable without hardware.
 
 from dataclasses import dataclass
 from typing import Optional
-from urllib.parse import urlparse
+
+from marilib.communication_adapter import parse_mqtt_url
 
 
 @dataclass(frozen=True)
@@ -59,17 +60,13 @@ def parse_connection(value: str) -> ConnectionSpec:
     if lowered in _SIMULATOR_VALUES:
         return ConnectionSpec(kind="simulator")
 
-    # MQTT — discriminated by the mqtt:// / mqtts:// scheme.
+    # MQTT — discriminated by the mqtt:// / mqtts:// scheme. Delegate the
+    # url → parts mapping to marilib's parse_mqtt_url, the single source of
+    # truth shared with swarmit (so the default-port logic can't drift).
     if lowered.startswith(("mqtt://", "mqtts://")):
-        parsed = urlparse(value)
-        use_tls = parsed.scheme == "mqtts"
-        host = parsed.hostname
-        port = parsed.port
+        host, port, use_tls, _user, _pass = parse_mqtt_url(value)
         if not host:
             raise ConnError(f"no host in MQTT connection string: {value!r}")
-        if port is None:
-            # Sensible MQTT defaults: 8883 for TLS, 1883 for plain.
-            port = 8883 if use_tls else 1883
         return ConnectionSpec(kind="mqtt", host=host, port=port, use_tls=use_tls)
 
     # Anything else that has a `scheme://` we don't recognize is an error,

--- a/dotbot/cli/gateway.py
+++ b/dotbot/cli/gateway.py
@@ -9,9 +9,12 @@ HDLC frames to/from an MQTT broker, so a `dotbot controller --conn
 mqtts://…` can reach the swarm from anywhere.
 
 Thin re-mount of marilib's `mari-edge`: wraps a `MarilibEdge` with a
-serial adapter and (optionally) an MQTT adapter. With no `--mqtt-url`
-it runs in **local-stdout mode** — received frames print to stdout, so
-a freshly-flashed gateway can be sanity-checked with zero MQTT infra.
+serial adapter and (optionally) an MQTT adapter. Without `--mqtt-url`
+it just prints received frames (handy to sanity-check a freshly-flashed
+gateway with zero MQTT infra); with `--mqtt-url` it bridges to the
+broker. Frame printing is on by default in both modes (`--no-print` to
+silence). Metrics probing is off (`metrics_probe_period=0`), so the
+print-only mode is passive — it doesn't inject traffic onto the link.
 
 Phase 1 is a raw bridge (mari frames + raw mari topics). DotBot-semantic
 MQTT topics are a later phase, tracked in the controller-CLI-redesign
@@ -24,7 +27,7 @@ import time
 import click
 
 
-def _run_gateway(port, mqtt_url):  # pragma: no cover - needs a real gateway
+def _run_gateway(port, mqtt_url, do_print):  # pragma: no cover - needs a gateway
     """Construct a MarilibEdge bridge and pump it until interrupted.
 
     Imports marilib lazily so `dotbot gateway --help` is cheap and the
@@ -36,15 +39,12 @@ def _run_gateway(port, mqtt_url):  # pragma: no cover - needs a real gateway
     from marilib.serial_uart import get_default_port
 
     port = port or get_default_port()
-    stdout_mode = mqtt_url is None
 
     def on_event(event, event_data):
-        # In local-stdout mode, surface received data frames so a fresh
-        # gateway can be eyeballed without a broker.
-        if stdout_mode and event == EdgeEvent.NODE_DATA:
-            src = getattr(event_data.header, "source", 0)
-            payload = getattr(event_data, "payload", b"")
-            click.echo(f"<- {src:016x}: {bytes(payload).hex()}")
+        if do_print and event == EdgeEvent.NODE_DATA:
+            click.echo(
+                f"<- {event_data.header.source:016x}: {event_data.payload.hex()}"
+            )
 
     mqtt_interface = None
     if mqtt_url is not None:
@@ -57,12 +57,15 @@ def _run_gateway(port, mqtt_url):  # pragma: no cover - needs a real gateway
             password=os.environ.get("DOTBOT_MQTT_PASS"),
         )
 
+    # metrics_probe_period=0 → MarilibEdge starts no metrics thread, so a
+    # print-only run stays passive (no probe traffic on the serial link).
     mari = MarilibEdge(
         on_event,
         serial_interface=SerialAdapter(port),
         mqtt_interface=mqtt_interface,
+        metrics_probe_period=0,
     )
-    where = mqtt_url if mqtt_url else "local-stdout"
+    where = mqtt_url if mqtt_url else "(no broker — print only)"
     click.echo(f"dotbot gateway: {port} <-> {where}", err=True)
     try:
         while True:
@@ -71,18 +74,16 @@ def _run_gateway(port, mqtt_url):  # pragma: no cover - needs a real gateway
     except KeyboardInterrupt:
         pass
     finally:
-        try:
-            mari.close()
-        except Exception:  # pylint: disable=broad-except
-            pass
+        mari.close()
 
 
 @click.command(
     name="gateway",
     help=(
         "Host-side Mari gateway bridge (UART <-> MQTT). Runs wherever the "
-        "gateway firmware is plugged in. Without --mqtt-url, prints received "
-        "frames to stdout (local debug mode)."
+        "gateway firmware is plugged in. With --mqtt-url it bridges to the "
+        "broker; without it, it just prints received frames. Printing is on "
+        "by default (--no-print to silence)."
     ),
 )
 @click.option(
@@ -97,11 +98,14 @@ def _run_gateway(port, mqtt_url):  # pragma: no cover - needs a real gateway
     "--mqtt-url",
     type=str,
     default=None,
-    help=(
-        "MQTT broker to bridge to (`mqtts://host:port`). Absent → "
-        "local-stdout debug mode."
-    ),
+    help="MQTT broker to bridge to (`mqtts://host:port`). Absent → print-only.",
 )
-def cmd(port, mqtt_url):
+@click.option(
+    "--print/--no-print",
+    "do_print",
+    default=True,
+    help="Print received frames to stdout (default: on).",
+)
+def cmd(port, mqtt_url, do_print):
     """Run the gateway bridge."""
-    _run_gateway(port, mqtt_url)
+    _run_gateway(port, mqtt_url, do_print)

--- a/dotbot/cli/gateway.py
+++ b/dotbot/cli/gateway.py
@@ -48,11 +48,14 @@ def _run_gateway(port, mqtt_url):  # pragma: no cover - needs a real gateway
 
     mqtt_interface = None
     if mqtt_url is not None:
-        # Broker credentials come from the environment (see the controller
-        # surface). They take effect once the marilib companion adds
-        # username/password to MQTTAdapter; until then anonymous connect.
-        mqtt_interface = MQTTAdapter.from_url(mqtt_url, is_edge=True)
-        _ = (os.environ.get("DOTBOT_MQTT_USER"), os.environ.get("DOTBOT_MQTT_PASS"))
+        # Broker credentials come from the environment (DOTBOT_MQTT_USER /
+        # DOTBOT_MQTT_PASS); they override any user:pass in the URL.
+        mqtt_interface = MQTTAdapter.from_url(
+            mqtt_url,
+            is_edge=True,
+            username=os.environ.get("DOTBOT_MQTT_USER"),
+            password=os.environ.get("DOTBOT_MQTT_PASS"),
+        )
 
     mari = MarilibEdge(
         on_event,

--- a/dotbot/cli/gateway.py
+++ b/dotbot/cli/gateway.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""`dotbot gateway` — host-side Mari gateway bridge.
+
+Runs on whatever computer the gateway firmware is plugged into (a
+laptop for a starter setup, a Pi for a permanent install). Bridges UART
+HDLC frames to/from an MQTT broker, so a `dotbot controller --conn
+mqtts://…` can reach the swarm from anywhere.
+
+Thin re-mount of marilib's `mari-edge`: wraps a `MarilibEdge` with a
+serial adapter and (optionally) an MQTT adapter. With no `--mqtt-url`
+it runs in **local-stdout mode** — received frames print to stdout, so
+a freshly-flashed gateway can be sanity-checked with zero MQTT infra.
+
+Phase 1 is a raw bridge (mari frames + raw mari topics). DotBot-semantic
+MQTT topics are a later phase, tracked in the controller-CLI-redesign
+plan.
+"""
+
+import os
+import time
+
+import click
+
+
+def _run_gateway(port, mqtt_url):  # pragma: no cover - needs a real gateway
+    """Construct a MarilibEdge bridge and pump it until interrupted.
+
+    Imports marilib lazily so `dotbot gateway --help` is cheap and the
+    command is importable without a serial port present.
+    """
+    from marilib.communication_adapter import MQTTAdapter, SerialAdapter
+    from marilib.marilib_edge import MarilibEdge
+    from marilib.model import EdgeEvent
+    from marilib.serial_uart import get_default_port
+
+    port = port or get_default_port()
+    stdout_mode = mqtt_url is None
+
+    def on_event(event, event_data):
+        # In local-stdout mode, surface received data frames so a fresh
+        # gateway can be eyeballed without a broker.
+        if stdout_mode and event == EdgeEvent.NODE_DATA:
+            src = getattr(event_data.header, "source", 0)
+            payload = getattr(event_data, "payload", b"")
+            click.echo(f"<- {src:016x}: {bytes(payload).hex()}")
+
+    mqtt_interface = None
+    if mqtt_url is not None:
+        # Broker credentials come from the environment (see the controller
+        # surface). They take effect once the marilib companion adds
+        # username/password to MQTTAdapter; until then anonymous connect.
+        mqtt_interface = MQTTAdapter.from_url(mqtt_url, is_edge=True)
+        _ = (os.environ.get("DOTBOT_MQTT_USER"), os.environ.get("DOTBOT_MQTT_PASS"))
+
+    mari = MarilibEdge(
+        on_event,
+        serial_interface=SerialAdapter(port),
+        mqtt_interface=mqtt_interface,
+    )
+    where = mqtt_url if mqtt_url else "local-stdout"
+    click.echo(f"dotbot gateway: {port} <-> {where}", err=True)
+    try:
+        while True:
+            mari.update()
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        try:
+            mari.close()
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+
+@click.command(
+    name="gateway",
+    help=(
+        "Host-side Mari gateway bridge (UART <-> MQTT). Runs wherever the "
+        "gateway firmware is plugged in. Without --mqtt-url, prints received "
+        "frames to stdout (local debug mode)."
+    ),
+)
+@click.option(
+    "-p",
+    "--port",
+    type=str,
+    default=None,
+    help="Serial port of the attached gateway firmware. Default: autodetect.",
+)
+@click.option(
+    "-m",
+    "--mqtt-url",
+    type=str,
+    default=None,
+    help=(
+        "MQTT broker to bridge to (`mqtts://host:port`). Absent → "
+        "local-stdout debug mode."
+    ),
+)
+def cmd(port, mqtt_url):
+    """Run the gateway bridge."""
+    _run_gateway(port, mqtt_url)

--- a/dotbot/cli/main.py
+++ b/dotbot/cli/main.py
@@ -38,7 +38,12 @@ _SUBCOMMANDS: Tuple[Tuple[str, str, str], ...] = (
     (
         "sim",
         "dotbot.cli.sim",
-        "Standalone simulator (equivalent to controller --adapter dotbot-simulator).",
+        "Standalone simulator (equivalent to controller --conn simulator).",
+    ),
+    (
+        "gateway",
+        "dotbot.cli.gateway",
+        "Host-side Mari gateway bridge (UART <-> MQTT).",
     ),
     (
         "swarm",

--- a/dotbot/cli/sim.py
+++ b/dotbot/cli/sim.py
@@ -3,14 +3,14 @@
 
 """`dotbot sim` — standalone simulator (no hardware).
 
-Equivalent to `dotbot controller --adapter dotbot-simulator`. The name
-advertises the no-hardware case so students can discover the offline
-path from `dotbot --help` without reading adapter docs.
+Equivalent to `dotbot controller --conn simulator`. The name advertises
+the no-hardware case so students can discover the offline path from
+`dotbot --help` without reading connection docs.
 
-Implementation: prepend `--adapter dotbot-simulator` to argv and
-delegate to the controller's Click command. A future refactor will
-turn this into a first-class entry that wires Engine + SimulatorAdapter
-directly.
+Implementation: prepend `--conn simulator` to argv and delegate to the
+controller's Click command. `dotbot sim --sailbot` forwards through to
+the controller's robot-type selector. A future refactor may turn this
+into a first-class entry (and possibly a separate sim process).
 """
 
 import click
@@ -31,8 +31,9 @@ from dotbot.controller_app import main as _controller_main
 def cmd(ctx):
     """Run a standalone simulator (no hardware required).
 
-    All other controller flags are forwarded as-is. Try
+    `dotbot sim` runs a dotbot simulator; `dotbot sim --sailbot` runs a
+    sailbot one. Other controller flags are forwarded as-is. Try
     `dotbot sim --help` for the full option list.
     """
-    args = ["--adapter", "dotbot-simulator", *ctx.args]
+    args = ["--conn", "simulator", *ctx.args]
     _controller_main.main(args=args, standalone_mode=True)

--- a/dotbot/controller.py
+++ b/dotbot/controller.py
@@ -122,6 +122,8 @@ class ControllerSettings:
     mqtt_host: str = MQTT_HOST_DEFAULT
     mqtt_port: int = MQTT_PORT_DEFAULT
     mqtt_use_tls: bool = False
+    mqtt_username: Optional[str] = None
+    mqtt_password: Optional[str] = None
     gw_address: str = GATEWAY_ADDRESS_DEFAULT
     network_id: str = NETWORK_ID_DEFAULT
     controller_http_port: int = CONTROLLER_HTTP_PORT_DEFAULT
@@ -691,6 +693,8 @@ class Controller:
                 port=self.settings.mqtt_port,
                 use_tls=self.settings.mqtt_use_tls,
                 network_id=int(self.settings.network_id, 16),
+                username=self.settings.mqtt_username,
+                password=self.settings.mqtt_password,
             )
         elif self.settings.adapter == "dotbot-simulator":
             self.adapter = DotBotSimulatorAdapter(

--- a/dotbot/controller_app.py
+++ b/dotbot/controller_app.py
@@ -9,7 +9,9 @@
 
 import asyncio
 import os
+import shutil
 import sys
+from pathlib import Path
 
 import click
 import serial
@@ -88,6 +90,46 @@ def _conn_to_settings(conn, swarm_id, sim_is_dotbot):
         return settings
     # simulator
     return {"adapter": "dotbot-simulator" if sim_is_dotbot else "sailbot-simulator"}
+
+
+def _maybe_scaffold_sim_state(explicit_init_state):
+    """Offer to drop an editable example world in the current directory.
+
+    `explicit_init_state` is the path set via `--simulator-init-state` or
+    the config file, or None when unspecified (the default world). Fires
+    only when nothing was specified and no `simulator_init_state.toml` is
+    here. An interactive run gets a [Y/n] prompt; declining — or a
+    non-interactive run (CI, a pipe) — leaves the cwd untouched and the
+    simulator falls back to the packaged world, so it always starts.
+    Writing the file lets the operator edit the simulated swarm
+    (positions, count, Mari vs default mode).
+    """
+    if explicit_init_state is not None:
+        return  # a path was set via --simulator-init-state or config
+    if Path(SIMULATOR_INIT_STATE_DEFAULT).is_file():
+        return  # a cwd file already exists; it'll be used as-is
+    if not sys.stdin.isatty():
+        return  # non-interactive: silently use the packaged default
+
+    target = Path.cwd() / SIMULATOR_INIT_STATE_DEFAULT
+    if not click.confirm(
+        f"No {SIMULATOR_INIT_STATE_DEFAULT} in this directory. "
+        "Create an editable example here?",
+        default=True,
+    ):
+        return
+
+    from dotbot.dotbot_simulator import packaged_init_state_path
+
+    try:
+        shutil.copy(packaged_init_state_path(), target)
+    except OSError as exc:
+        click.echo(
+            f"Could not write {target}: {exc}; using the built-in world.",
+            err=True,
+        )
+        return
+    click.echo(f"Created {target} — edit it to customize the simulated swarm.")
 
 
 @click.command()
@@ -228,6 +270,15 @@ def main(
     # adapter + transport settings. The internal `adapter` enum stays an
     # implementation detail — the CLI never exposes it.
     conn_settings = _conn_to_settings(conn, swarm_id, sim_is_dotbot)
+
+    # For a simulator connection with no init-state set (CLI default is
+    # None, so fold in any config value), offer to scaffold an editable
+    # world file in the cwd. resolve_init_state_path then picks up the
+    # freshly-written file (or the packaged world if declined/non-tty).
+    if conn_settings.get("adapter", "").endswith("simulator"):
+        _maybe_scaffold_sim_state(
+            simulator_init_state or file_data.get("simulator_init_state")
+        )
 
     cli_args = {
         "gw_address": gw_address,

--- a/dotbot/controller_app.py
+++ b/dotbot/controller_app.py
@@ -113,7 +113,6 @@ def _conn_to_settings(conn, swarm_id, sim_is_dotbot):
     help=f"Gateway address in hex. Defaults to {GATEWAY_ADDRESS_DEFAULT:>0{16}}",
 )
 @click.option(
-    "-c",
     "--controller-http-port",
     type=int,
     help=f"Controller HTTP port of the REST API. Defaults to '{CONTROLLER_HTTP_PORT_DEFAULT}'",

--- a/dotbot/controller_app.py
+++ b/dotbot/controller_app.py
@@ -26,6 +26,19 @@ from dotbot.cli._conn import ConnError, needs_swarm_id, parse_connection
 from dotbot.controller import Controller, ControllerSettings
 from dotbot.logger import setup_logging
 
+# Old transport/identity config keys replaced by `conn` / `swarm_id`.
+# Present-in-config triggers a warning and is dropped.
+_LEGACY_TOML_KEYS = {
+    "adapter",
+    "mqtt_host",
+    "mqtt_port",
+    "mqtt_use_tls",
+    "network_id",
+    "swarmit_network_id",
+    "port",
+    "baudrate",
+}
+
 
 def _conn_to_settings(conn, swarm_id, sim_is_dotbot):
     """Map `--conn` + `--swarm-id` into internal ControllerSettings fields.
@@ -200,6 +213,17 @@ def main(
     conn = conn if conn is not None else file_data.get("conn")
     swarm_id = swarm_id if swarm_id is not None else file_data.get("swarm_id")
 
+    # Warn (and drop) legacy transport keys in a config file — they're
+    # superseded by `conn` / `swarm_id` and silently flowing them through
+    # would mask a stale config.
+    legacy = sorted(_LEGACY_TOML_KEYS & set(file_data))
+    if legacy:
+        click.echo(
+            f"warning: ignoring legacy config key(s) {legacy}; "
+            "use `conn` and `swarm_id` instead.",
+            err=True,
+        )
+
     # Translate the single `--conn` connection string into the internal
     # adapter + transport settings. The internal `adapter` enum stays an
     # implementation detail — the CLI never exposes it.
@@ -218,9 +242,10 @@ def main(
         "csv_data_output": csv_data_output,
     }
 
-    # Settings precedence: defaults < config-file (non-conn keys) < conn
-    # translation < other CLI flags.
-    data = {k: v for k, v in file_data.items() if k not in ("conn", "swarm_id")}
+    # Settings precedence: defaults < config-file (non-conn/legacy keys) <
+    # conn translation < other CLI flags.
+    dropped = _LEGACY_TOML_KEYS | {"conn", "swarm_id"}
+    data = {k: v for k, v in file_data.items() if k not in dropped}
     data.update(conn_settings)
     data.update({k: v for k, v in cli_args.items() if v is not None})
 

--- a/dotbot/controller_app.py
+++ b/dotbot/controller_app.py
@@ -8,6 +8,7 @@
 """Main module of the Dotbot controller command line tool."""
 
 import asyncio
+import os
 import sys
 
 import click
@@ -15,72 +16,101 @@ import serial
 import toml
 
 from dotbot import (
-    CONTROLLER_ADAPTER_DEFAULT,
     CONTROLLER_HTTP_PORT_DEFAULT,
     GATEWAY_ADDRESS_DEFAULT,
     MAP_SIZE_DEFAULT,
-    MQTT_HOST_DEFAULT,
-    MQTT_PORT_DEFAULT,
-    NETWORK_ID_DEFAULT,
-    SERIAL_BAUDRATE_DEFAULT,
-    SERIAL_PORT_DEFAULT,
     SIMULATOR_INIT_STATE_DEFAULT,
     pydotbot_version,
 )
+from dotbot.cli._conn import ConnError, needs_swarm_id, parse_connection
 from dotbot.controller import Controller, ControllerSettings
 from dotbot.logger import setup_logging
 
 
+def _conn_to_settings(conn, swarm_id, sim_is_dotbot):
+    """Map `--conn` + `--swarm-id` into internal ControllerSettings fields.
+
+    The internal `adapter` enum (`cloud`/`edge`/`dotbot-simulator`/…) is
+    an implementation detail; the CLI only ever sees `--conn`. Broker
+    credentials come from the environment (`DOTBOT_MQTT_USER` /
+    `DOTBOT_MQTT_PASS`), never the URL or a flag.
+
+    Raises `click.ClickException` for a malformed `--conn` or a missing
+    `--swarm-id` on an mqtt connection.
+    """
+    if conn is None:
+        raise click.ClickException(
+            "no connection given. Pass --conn (-n) with one of:\n"
+            "  mqtts://host:port   (an MQTT broker; also needs --swarm-id)\n"
+            "  /dev/ttyACM0        (a serial gateway)\n"
+            "  simulator           (no hardware)"
+        )
+    try:
+        parsed = parse_connection(conn)
+    except ConnError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if needs_swarm_id(parsed) and not swarm_id:
+        raise click.ClickException(
+            f"--conn {conn} needs --swarm-id: the broker carries multiple "
+            "swarms; --swarm-id selects yours."
+        )
+
+    if parsed.kind == "mqtt":
+        settings = {
+            "adapter": "cloud",
+            "mqtt_host": parsed.host,
+            "mqtt_port": parsed.port,
+            "mqtt_use_tls": parsed.use_tls,
+            "mqtt_username": os.environ.get("DOTBOT_MQTT_USER"),
+            "mqtt_password": os.environ.get("DOTBOT_MQTT_PASS"),
+        }
+        if swarm_id:
+            settings["network_id"] = swarm_id
+        return settings
+    if parsed.kind == "serial":
+        settings = {"adapter": "edge", "port": parsed.serial_port}
+        if swarm_id:
+            settings["network_id"] = swarm_id
+        return settings
+    # simulator
+    return {"adapter": "dotbot-simulator" if sim_is_dotbot else "sailbot-simulator"}
+
+
 @click.command()
 @click.option(
-    "-a",
-    "--adapter",
-    type=click.Choice(
-        ["serial", "edge", "cloud", "dotbot-simulator", "sailbot-simulator"]
+    "-n",
+    "--conn",
+    "--connection",
+    "conn",
+    type=str,
+    help=(
+        "Connection to the swarm — one discriminated string: an MQTT "
+        "broker `mqtts://host:port`, a serial device path `/dev/ttyACM0`, "
+        "or `simulator`."
     ),
-    help=f"Controller interface adapter. Defaults to {CONTROLLER_ADAPTER_DEFAULT}",
 )
 @click.option(
-    "-p",
-    "--port",
+    "-s",
+    "--swarm-id",
+    "swarm_id",
     type=str,
-    help=f"Serial port used by 'serial' and 'edge' adapters. Defaults to '{SERIAL_PORT_DEFAULT}'",
+    help=(
+        "Swarm id in hex. Required for an mqtt connection (the broker "
+        "carries many swarms); ignored for serial/simulator."
+    ),
 )
 @click.option(
-    "-b",
-    "--baudrate",
-    type=int,
-    help=f"Serial baudrate used by 'serial' and 'edge' adapters. Defaults to {SERIAL_BAUDRATE_DEFAULT}",
-)
-@click.option(
-    "-H",
-    "--mqtt-host",
-    type=str,
-    help=f"MQTT host used by cloud adapter. Default: {MQTT_HOST_DEFAULT}.",
-)
-@click.option(
-    "-P",
-    "--mqtt-port",
-    type=int,
-    help=f"MQTT port used by cloud adapter. Default: {MQTT_PORT_DEFAULT}.",
-)
-@click.option(
-    "-T",
-    "--mqtt-use_tls/--no-mqtt-use_tls",
-    default=None,
-    help="Use TLS with MQTT (for cloud adapter).",
+    "--dotbot/--sailbot",
+    "sim_is_dotbot",
+    default=True,
+    help="With `--conn simulator`: which robot to simulate. Default: --dotbot.",
 )
 @click.option(
     "-g",
     "--gw-address",
     type=str,
     help=f"Gateway address in hex. Defaults to {GATEWAY_ADDRESS_DEFAULT:>0{16}}",
-)
-@click.option(
-    "-s",
-    "--network-id",
-    type=str,
-    help=f"Network ID in hex. Defaults to {NETWORK_ID_DEFAULT:>0{4}}",
 )
 @click.option(
     "-c",
@@ -143,14 +173,10 @@ from dotbot.logger import setup_logging
     help=f"Path to the simulator initial state .toml file. Defaults to '{SIMULATOR_INIT_STATE_DEFAULT}'.",
 )
 def main(
-    adapter,
-    port,
-    baudrate,
-    mqtt_host,
-    mqtt_port,
-    mqtt_use_tls,
+    conn,
+    swarm_id,
+    sim_is_dotbot,
     gw_address,
-    network_id,
     controller_http_port,
     map_size,
     background_map,
@@ -166,16 +192,22 @@ def main(
     # welcome sentence
     print(f"Welcome to the DotBots controller (version: {pydotbot_version()}).")
 
-    # The priority order is CLI > ConfigFile (optional) > Defaults
+    # The priority order is CLI > ConfigFile (optional) > Defaults.
+    # The config file may carry `conn` / `swarm_id` too; CLI wins.
+    file_data = {}
+    if config_path:
+        file_data = toml.load(config_path)
+
+    conn = conn if conn is not None else file_data.get("conn")
+    swarm_id = swarm_id if swarm_id is not None else file_data.get("swarm_id")
+
+    # Translate the single `--conn` connection string into the internal
+    # adapter + transport settings. The internal `adapter` enum stays an
+    # implementation detail — the CLI never exposes it.
+    conn_settings = _conn_to_settings(conn, swarm_id, sim_is_dotbot)
+
     cli_args = {
-        "adapter": adapter,
-        "port": port,
-        "baudrate": baudrate,
-        "mqtt_host": mqtt_host,
-        "mqtt_port": mqtt_port,
-        "mqtt_use_tls": mqtt_use_tls,
         "gw_address": gw_address,
-        "network_id": network_id,
         "controller_http_port": controller_http_port,
         "map_size": map_size,
         "background_map": background_map,
@@ -187,11 +219,10 @@ def main(
         "csv_data_output": csv_data_output,
     }
 
-    data = {}
-    if config_path:
-        file_data = toml.load(config_path)
-        data.update(file_data)
-
+    # Settings precedence: defaults < config-file (non-conn keys) < conn
+    # translation < other CLI flags.
+    data = {k: v for k, v in file_data.items() if k not in ("conn", "swarm_id")}
+    data.update(conn_settings)
     data.update({k: v for k, v in cli_args.items() if v is not None})
 
     controller_settings = ControllerSettings(**data)

--- a/dotbot/dotbot_simulator.py
+++ b/dotbot/dotbot_simulator.py
@@ -23,7 +23,7 @@ import toml
 from dotbot_utils.protocol import Frame, Header, Packet
 from pydantic import BaseModel, Field, model_validator
 
-from dotbot import GATEWAY_ADDRESS_DEFAULT
+from dotbot import GATEWAY_ADDRESS_DEFAULT, SIMULATOR_INIT_STATE_DEFAULT
 from dotbot.logger import LOGGER
 from dotbot.protocol import ControlModeType, PayloadDotBotAdvertisement, PayloadType
 
@@ -743,6 +743,29 @@ class MariNetworkSimulator:
                 self._cond.wait(timeout=wait)
 
 
+def packaged_init_state_path() -> Path:
+    """Absolute path to the default simulator world shipped in the package."""
+    return Path(__file__).with_name(SIMULATOR_INIT_STATE_DEFAULT)
+
+
+def resolve_init_state_path(path: str) -> str:
+    """Resolve the simulator init-state .toml to load.
+
+    An existing file — an explicit ``--simulator-init-state`` path, or a
+    ``simulator_init_state.toml`` in the working directory — is used as
+    given. When the default is requested and no such file is present,
+    fall back to the world shipped inside the package, so the no-hardware
+    path (``dotbot sim`` / ``--conn simulator``) works from any directory
+    and from a pip-installed wheel. An explicit path that does not exist
+    is returned unchanged so the caller gets a clear FileNotFoundError.
+    """
+    if Path(path).is_file():
+        return path
+    if path == SIMULATOR_INIT_STATE_DEFAULT:
+        return str(packaged_init_state_path())
+    return path
+
+
 class DotBotSimulatorCommunicationInterface:
     """Bidirectional serial interface to control simulated robots"""
 
@@ -751,7 +774,9 @@ class DotBotSimulatorCommunicationInterface:
         self.on_frame_received = on_frame_received
         self._stp_event = threading.Event()
         self.main_thread = threading.Thread(target=self.run, daemon=True)
-        init_state = InitStateToml(**toml.load(simulator_init_state))
+        init_state = InitStateToml(
+            **toml.load(resolve_init_state_path(simulator_init_state))
+        )
         self._network = init_state.network
         self.dotbots = [
             DotBotSimulator(

--- a/dotbot/simulator_init_state.toml
+++ b/dotbot/simulator_init_state.toml
@@ -1,0 +1,35 @@
+# This file is used to create and configure simulated DotBot instances for the simulator.
+# It is only used when the flag `-p dotbot-simulator` is set, otherwise it is ignored.
+
+[network]
+pdr = 100              # packet delivery ratio for "default" network mode (0-100)
+uplink_pdr = 100       # PDR for DotBot→gateway direction in "mari" mode
+downlink_pdr = 100     # PDR for gateway→DotBot direction in "mari" mode
+slot_duration_ms = 1.236  # Mari TSCH slot duration in ms (from mac.h)
+mqtt_latency_ms = 0.0  # one-way MQTT broker latency in ms (applied in both modes)
+
+[[dotbots]]
+address = "BADCAFE111111111" # DotBot unique address
+calibrated = 0xff # optional, defaults to only first lighthouse calibrated
+pos_x = 1000 # [0, 2_000] in mm
+pos_y = 250 # [0, 2_000]
+direction = 0 # [0, 360] in degrees, 0 is facing north, increasing clockwise
+network_mode = "default" # optional, defaults to "default", can be set to "mari"
+
+[[dotbots]]
+address = "DEADBEEF22222222"
+pos_x = 1500
+pos_y = 200
+direction = 180
+
+[[dotbots]]
+address = "B0B0F00D33333333"
+pos_x = 1_500
+pos_y = 1_500
+direction = 180
+
+[[dotbots]]
+address = "BADC0DE444444444"
+pos_x = 1_000
+pos_y = 1_000
+direction = 360

--- a/dotbot/tests/test_adapter.py
+++ b/dotbot/tests/test_adapter.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -191,3 +192,33 @@ async def test_sailbot_simulator_adapter(_):
         adapter.simulator.write.assert_called_once_with(frame.to_bytes())
         adapter.close()
         adapter.simulator.stop.assert_called_once()
+
+
+def test_simulator_adapter_close_before_start_is_noop():
+    """close() must not raise when start() never assigned `simulator`
+    (e.g. start() failed loading the init state)."""
+    adapter = DotBotSimulatorAdapter()
+    adapter.close()  # no AttributeError
+
+
+def test_resolve_init_state_path_falls_back_to_packaged(tmp_path, monkeypatch):
+    """The default init-state resolves to the packaged world when no file
+    exists in the cwd, so `dotbot sim` works from any directory."""
+    from dotbot import SIMULATOR_INIT_STATE_DEFAULT
+    from dotbot.dotbot_simulator import resolve_init_state_path
+
+    monkeypatch.chdir(tmp_path)  # a dir without simulator_init_state.toml
+    resolved = resolve_init_state_path(SIMULATOR_INIT_STATE_DEFAULT)
+    assert Path(resolved).is_file()
+    assert Path(resolved).name == SIMULATOR_INIT_STATE_DEFAULT
+
+    # A cwd file is preferred over the packaged copy.
+    local = tmp_path / SIMULATOR_INIT_STATE_DEFAULT
+    local.write_text('[[dotbots]]\naddress = "0000000000000001"\n')
+    assert (
+        resolve_init_state_path(SIMULATOR_INIT_STATE_DEFAULT)
+        == SIMULATOR_INIT_STATE_DEFAULT
+    )
+
+    # An explicit, missing path is returned unchanged (caller gets the error).
+    assert resolve_init_state_path("nope/missing.toml") == "nope/missing.toml"

--- a/dotbot/tests/test_cli_dispatcher.py
+++ b/dotbot/tests/test_cli_dispatcher.py
@@ -44,6 +44,7 @@ _needs_frontend = pytest.mark.skipif(
 EXPECTED_SUBCOMMANDS = {
     "controller",
     "sim",
+    "gateway",
     "swarm",
     "calibrate-lh2",
     "demo",

--- a/dotbot/tests/test_conn.py
+++ b/dotbot/tests/test_conn.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the `--conn` connection-string parser (`dotbot.cli._conn`)."""
+
+import pytest
+
+from dotbot.cli._conn import ConnError, needs_swarm_id, parse_connection
+
+
+def test_parse_mqtt_tls():
+    c = parse_connection("mqtts://argus.paris.inria.fr:8883")
+    assert c.kind == "mqtt"
+    assert c.host == "argus.paris.inria.fr"
+    assert c.port == 8883
+    assert c.use_tls is True
+
+
+def test_parse_mqtt_plain():
+    c = parse_connection("mqtt://localhost:1883")
+    assert c.kind == "mqtt"
+    assert c.host == "localhost"
+    assert c.port == 1883
+    assert c.use_tls is False
+
+
+def test_parse_mqtt_default_ports():
+    # No explicit port → 8883 for TLS, 1883 for plain.
+    assert parse_connection("mqtts://host").port == 8883
+    assert parse_connection("mqtt://host").port == 1883
+
+
+def test_parse_mqtt_missing_host_errors():
+    with pytest.raises(ConnError):
+        parse_connection("mqtts://:8883")
+
+
+def test_parse_serial_device_path():
+    c = parse_connection("/dev/ttyACM0")
+    assert c.kind == "serial"
+    assert c.serial_port == "/dev/ttyACM0"
+
+
+def test_parse_serial_macos_usbmodem():
+    c = parse_connection("/dev/tty.usbmodem0007745943981")
+    assert c.kind == "serial"
+    assert c.serial_port == "/dev/tty.usbmodem0007745943981"
+
+
+def test_parse_serial_windows_com():
+    c = parse_connection("COM3")
+    assert c.kind == "serial"
+    assert c.serial_port == "COM3"
+
+
+def test_parse_simulator_both_spellings():
+    assert parse_connection("simulator").kind == "simulator"
+    assert parse_connection("sim").kind == "simulator"
+
+
+def test_parse_simulator_case_insensitive():
+    assert parse_connection("Simulator").kind == "simulator"
+
+
+def test_parse_unknown_scheme_errors():
+    # A scheme we don't recognize is an error, not a silent serial path.
+    with pytest.raises(ConnError):
+        parse_connection("http://example.com:8000")
+    with pytest.raises(ConnError):
+        parse_connection("serial:///dev/ttyACM0")  # scheme deliberately unsupported
+
+
+def test_parse_empty_errors():
+    with pytest.raises(ConnError):
+        parse_connection("")
+
+
+def test_needs_swarm_id_only_for_mqtt():
+    assert needs_swarm_id(parse_connection("mqtts://host:8883")) is True
+    assert needs_swarm_id(parse_connection("/dev/ttyACM0")) is False
+    assert needs_swarm_id(parse_connection("simulator")) is False

--- a/dotbot/tests/test_controller_app.py
+++ b/dotbot/tests/test_controller_app.py
@@ -10,59 +10,20 @@ from click.testing import CliRunner
 
 from dotbot.controller_app import main
 
-MAIN_HELP_EXPECTED = """Usage: main [OPTIONS]
 
-  DotBotController, universal SailBot and DotBot controller.
-
-Options:
-  -a, --adapter [serial|edge|cloud|dotbot-simulator|sailbot-simulator]
-                                  Controller interface adapter. Defaults to
-                                  serial
-  -p, --port TEXT                 Serial port used by 'serial' and 'edge'
-                                  adapters. Defaults to '/dev/ttyACM0'
-  -b, --baudrate INTEGER          Serial baudrate used by 'serial' and 'edge'
-                                  adapters. Defaults to 1000000
-  -H, --mqtt-host TEXT            MQTT host used by cloud adapter. Default:
-                                  localhost.
-  -P, --mqtt-port INTEGER         MQTT port used by cloud adapter. Default:
-                                  1883.
-  -T, --mqtt-use_tls / --no-mqtt-use_tls
-                                  Use TLS with MQTT (for cloud adapter).
-  -g, --gw-address TEXT           Gateway address in hex. Defaults to
-                                  0000000000000000
-  -s, --network-id TEXT           Network ID in hex. Defaults to 0000
-  -c, --controller-http-port INTEGER
-                                  Controller HTTP port of the REST API. Defaults
-                                  to '8000'
-  -w, --webbrowser / --no-webbrowser
-                                  Open a web browser automatically
-  -v, --verbose                   Run in verbose mode (all payloads received are
-                                  printed in terminal)
-  --log-level [debug|info|warning|error]
-                                  Logging level. Defaults to info
-  --log-output PATH               Filename where logs are redirected
-  --csv-data-output PATH          Filename where CSV data logs are stored. If
-                                  not set, CSV data logging is disabled.
-  --config-path FILE              Path to a .toml configuration file.
-  -m, --map-size TEXT             Map size in mm. Defaults to '2000x2000'
-  -M, --background-map FILE       Path to a background map image file in png
-                                  format. The image shouldbe a top-down view of
-                                  the environment, with 1024 pixels width and a
-                                  height proportional to the real map size. The
-                                  map size should be set with the --map-size
-                                  option (default: 2000x2000).
-  --simulator-init-state FILE     Path to the simulator initial state .toml
-                                  file. Defaults to 'simulator_init_state.toml'.
-  --help                          Show this message and exit.
-"""
-
-
-@pytest.mark.skipif(sys.platform != "linux", reason="Serial port is different")
 def test_main_help():
+    """Help advertises the new `--conn` / `--swarm-id` surface and no
+    longer the dropped `--adapter` / `-H/-P/-T` flags."""
     runner = CliRunner()
     result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
-    assert result.output == MAIN_HELP_EXPECTED
+    assert "--conn" in result.output
+    assert "--swarm-id" in result.output
+    assert "--sailbot" in result.output
+    # Dropped flags must be gone.
+    assert "--adapter" not in result.output
+    assert "--mqtt-host" not in result.output
+    assert "--network-id" not in result.output
 
 
 @patch("dotbot_utils.serial_interface.serial.Serial.open")
@@ -71,15 +32,31 @@ def test_main_help():
 def test_main(run, version, _):
     version.return_value = "test"
     runner = CliRunner()
-    result = runner.invoke(main)
+    # A connection is now required; `simulator` needs no hardware/swarm-id.
+    result = runner.invoke(main, ["--conn", "simulator"])
     assert result.exit_code == 0
     assert "Welcome to the DotBots controller (version: test)." in result.output
     run.assert_called_once()
 
     version.side_effect = PackageNotFoundError
-    result = runner.invoke(main)
+    result = runner.invoke(main, ["--conn", "simulator"])
     assert result.exit_code == 0
     assert "Welcome to the DotBots controller (version: unknown)." in result.output
+
+
+def test_main_without_conn_errors():
+    """No `--conn` → a clear error listing the connection forms."""
+    runner = CliRunner()
+    result = runner.invoke(main, [])
+    assert result.exit_code != 0
+    assert "mqtts://" in result.output and "simulator" in result.output
+
+
+def test_main_mqtt_without_swarm_id_errors():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--conn", "mqtts://argus:8883"])
+    assert result.exit_code != 0
+    assert "swarm-id" in result.output
 
 
 @patch("dotbot_utils.serial_interface.serial.Serial.open")
@@ -87,16 +64,16 @@ def test_main(run, version, _):
 def test_main_interrupts(run, _):
     runner = CliRunner()
     run.side_effect = KeyboardInterrupt
-    result = runner.invoke(main)
+    result = runner.invoke(main, ["--conn", "simulator"])
     assert result.exit_code == 0
 
     runner = CliRunner()
     run.side_effect = SystemExit
-    result = runner.invoke(main)
+    result = runner.invoke(main, ["--conn", "simulator"])
     assert result.exit_code == 0
 
     run.side_effect = serial.serialutil.SerialException("serial test error")
-    result = runner.invoke(main)
+    result = runner.invoke(main, ["--conn", "/dev/ttyACM0"])
     assert result.exit_code != 0
     assert "Serial error: serial test error" in result.output
 
@@ -105,12 +82,13 @@ def test_main_interrupts(run, _):
 @patch("dotbot_utils.serial_interface.serial.Serial.open")
 @patch("dotbot.controller_app.Controller")
 def test_main_with_config(controller, _, tmp_path):
+    """Config file carries `conn` + `swarm_id` (new keys); CLI absent."""
     log_file = tmp_path / "logfile.log"
     config_file = tmp_path / "config.toml"
     config_file.write_text(
         f"""
-adapter = "serial"
-network_id = "AA26"
+conn = "mqtts://argus:8883"
+swarm_id = "AA26"
 log_level = "debug"
 log_output = "{log_file}"
 """
@@ -118,7 +96,9 @@ log_output = "{log_file}"
 
     runner = CliRunner()
     runner.invoke(main, ["--config-path", config_file.as_posix()])
-    assert controller.call_args.args[0].network_id == "AA26"
-    assert controller.call_args.args[0].adapter == "serial"
-    assert controller.call_args.args[0].log_level == "debug"
-    assert controller.call_args.args[0].log_output == str(log_file)
+    settings = controller.call_args.args[0]
+    assert settings.network_id == "AA26"
+    assert settings.adapter == "cloud"
+    assert settings.mqtt_host == "argus"
+    assert settings.log_level == "debug"
+    assert settings.log_output == str(log_file)

--- a/dotbot/tests/test_controller_app.py
+++ b/dotbot/tests/test_controller_app.py
@@ -102,3 +102,22 @@ log_output = "{log_file}"
     assert settings.mqtt_host == "argus"
     assert settings.log_level == "debug"
     assert settings.log_output == str(log_file)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Doesn't work on Windows")
+@patch("dotbot_utils.serial_interface.serial.Serial.open")
+@patch("dotbot.controller_app.Controller")
+def test_main_warns_on_legacy_config_keys(controller, _, tmp_path):
+    """A config file with old transport keys (adapter/mqtt_host/...) gets a
+    warning, and those keys are dropped (conn/swarm_id drive it)."""
+    config_file = tmp_path / "cfg.toml"
+    config_file.write_text(
+        'conn = "simulator"\nadapter = "serial"\nmqtt_host = "stale"\n'
+    )
+    runner = CliRunner()
+    result = runner.invoke(main, ["--config-path", config_file.as_posix()])
+    assert "legacy config key" in result.output
+    settings = controller.call_args.args[0]
+    # conn=simulator wins; the stale adapter/mqtt_host are ignored.
+    assert settings.adapter == "dotbot-simulator"
+    assert settings.mqtt_host != "stale"

--- a/dotbot/tests/test_controller_app.py
+++ b/dotbot/tests/test_controller_app.py
@@ -121,3 +121,63 @@ def test_main_warns_on_legacy_config_keys(controller, _, tmp_path):
     # conn=simulator wins; the stale adapter/mqtt_host are ignored.
     assert settings.adapter == "dotbot-simulator"
     assert settings.mqtt_host != "stale"
+
+
+def test_scaffold_sim_state_creates_example_when_accepted(tmp_path, monkeypatch):
+    """Interactive simulator run with nothing specified + `y` writes an
+    editable `simulator_init_state.toml` in the cwd."""
+    from dotbot import SIMULATOR_INIT_STATE_DEFAULT
+    from dotbot.controller_app import _maybe_scaffold_sim_state
+
+    monkeypatch.chdir(tmp_path)
+    with patch("sys.stdin") as stdin, patch("click.confirm", return_value=True):
+        stdin.isatty.return_value = True
+        _maybe_scaffold_sim_state(None)  # the value main() passes by default
+    created = tmp_path / SIMULATOR_INIT_STATE_DEFAULT
+    assert created.is_file()
+    assert "[[dotbots]]" in created.read_text()
+
+
+def test_scaffold_sim_state_declined_writes_nothing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from dotbot import SIMULATOR_INIT_STATE_DEFAULT
+    from dotbot.controller_app import _maybe_scaffold_sim_state
+
+    with patch("sys.stdin") as stdin, patch("click.confirm", return_value=False):
+        stdin.isatty.return_value = True
+        _maybe_scaffold_sim_state(None)
+    assert not (tmp_path / SIMULATOR_INIT_STATE_DEFAULT).exists()
+
+
+def test_scaffold_sim_state_noninteractive_never_prompts(tmp_path, monkeypatch):
+    """No TTY (CI, a pipe) → no prompt, no file; the packaged world is used."""
+    monkeypatch.chdir(tmp_path)
+    from dotbot import SIMULATOR_INIT_STATE_DEFAULT
+    from dotbot.controller_app import _maybe_scaffold_sim_state
+
+    with patch("sys.stdin") as stdin, patch("click.confirm") as confirm:
+        stdin.isatty.return_value = False
+        _maybe_scaffold_sim_state(None)
+        confirm.assert_not_called()
+    assert not (tmp_path / SIMULATOR_INIT_STATE_DEFAULT).exists()
+
+
+def test_scaffold_sim_state_skips_when_explicit_path_given(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from dotbot.controller_app import _maybe_scaffold_sim_state
+
+    with patch("sys.stdin") as stdin, patch("click.confirm") as confirm:
+        stdin.isatty.return_value = True
+        _maybe_scaffold_sim_state("my_world.toml")  # explicit path → no prompt
+        confirm.assert_not_called()
+
+
+@patch("dotbot_utils.serial_interface.serial.Serial.open")
+@patch("dotbot.controller.Controller.run")
+@patch("dotbot.controller_app._maybe_scaffold_sim_state")
+def test_main_simulator_offers_scaffold_with_none(scaffold, _run, _serial):
+    """Regression: `--conn simulator` with no flag/config must reach the
+    scaffold with None (the option default), not a sentinel string."""
+    runner = CliRunner()
+    runner.invoke(main, ["--conn", "simulator"])
+    scaffold.assert_called_once_with(None)

--- a/dotbot/tests/test_controller_conn.py
+++ b/dotbot/tests/test_controller_conn.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the controller's `--conn` / `--swarm-id` CLI surface.
+
+These exercise `_conn_to_settings` (pure translation + validation) and
+the Click wiring, without starting a real controller / MQTT / serial.
+"""
+
+import click
+import pytest
+
+from dotbot.controller_app import _conn_to_settings
+
+
+def test_mqtt_conn_maps_to_cloud_adapter():
+    s = _conn_to_settings("mqtts://argus:8883", "1234", sim_is_dotbot=True)
+    assert s["adapter"] == "cloud"
+    assert s["mqtt_host"] == "argus"
+    assert s["mqtt_port"] == 8883
+    assert s["mqtt_use_tls"] is True
+    assert s["network_id"] == "1234"
+
+
+def test_mqtt_conn_without_swarm_id_errors():
+    with pytest.raises(click.ClickException) as exc:
+        _conn_to_settings("mqtts://argus:8883", None, sim_is_dotbot=True)
+    assert "swarm-id" in str(exc.value)
+
+
+def test_serial_conn_maps_to_edge_adapter_no_swarm_id_needed():
+    s = _conn_to_settings("/dev/ttyACM0", None, sim_is_dotbot=True)
+    assert s["adapter"] == "edge"
+    assert s["port"] == "/dev/ttyACM0"
+    # No swarm-id required, and none injected when absent.
+    assert "network_id" not in s
+
+
+def test_serial_conn_keeps_swarm_id_when_given():
+    s = _conn_to_settings("/dev/ttyACM0", "00aa", sim_is_dotbot=True)
+    assert s["adapter"] == "edge"
+    assert s["network_id"] == "00aa"
+
+
+def test_simulator_conn_maps_to_dotbot_simulator():
+    s = _conn_to_settings("simulator", None, sim_is_dotbot=True)
+    assert s["adapter"] == "dotbot-simulator"
+
+
+def test_simulator_conn_sailbot():
+    s = _conn_to_settings("simulator", None, sim_is_dotbot=False)
+    assert s["adapter"] == "sailbot-simulator"
+
+
+def test_sim_alias_spelling():
+    assert _conn_to_settings("sim", None, sim_is_dotbot=True)["adapter"] == (
+        "dotbot-simulator"
+    )
+
+
+def test_no_conn_errors_with_guidance():
+    with pytest.raises(click.ClickException) as exc:
+        _conn_to_settings(None, None, sim_is_dotbot=True)
+    msg = str(exc.value)
+    assert "mqtts://" in msg and "simulator" in msg
+
+
+def test_malformed_conn_errors():
+    with pytest.raises(click.ClickException):
+        _conn_to_settings("http://nope:1", "1234", sim_is_dotbot=True)
+
+
+def test_env_credentials_threaded_into_mqtt_settings(monkeypatch):
+    monkeypatch.setenv("DOTBOT_MQTT_USER", "alice")
+    monkeypatch.setenv("DOTBOT_MQTT_PASS", "s3cret")
+    s = _conn_to_settings("mqtts://argus:8883", "1234", sim_is_dotbot=True)
+    assert s["mqtt_username"] == "alice"
+    assert s["mqtt_password"] == "s3cret"
+
+
+def test_env_credentials_absent_are_none(monkeypatch):
+    monkeypatch.delenv("DOTBOT_MQTT_USER", raising=False)
+    monkeypatch.delenv("DOTBOT_MQTT_PASS", raising=False)
+    s = _conn_to_settings("mqtts://argus:8883", "1234", sim_is_dotbot=True)
+    assert s["mqtt_username"] is None
+    assert s["mqtt_password"] is None

--- a/dotbot/tests/test_gateway.py
+++ b/dotbot/tests/test_gateway.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for `dotbot gateway` — the CLI surface, not the live bridge.
+
+The bridge itself (`_run_gateway`) needs a real serial gateway, so it's
+mocked here; we check flag parsing and that the command forwards
+`--port` / `--mqtt-url` correctly.
+"""
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from dotbot.cli.gateway import cmd as gateway_cmd
+
+
+def test_gateway_help_mentions_stdout_mode():
+    result = CliRunner().invoke(gateway_cmd, ["--help"])
+    assert result.exit_code == 0
+    assert "--port" in result.output
+    assert "--mqtt-url" in result.output
+    # The no-broker default behaviour is documented.
+    assert "stdout" in result.output.lower()
+
+
+@patch("dotbot.cli.gateway._run_gateway")
+def test_gateway_forwards_port_and_mqtt_url(run):
+    result = CliRunner().invoke(
+        gateway_cmd,
+        ["--port", "/dev/ttyACM0", "--mqtt-url", "mqtts://argus:8883"],
+    )
+    assert result.exit_code == 0, result.output
+    run.assert_called_once_with("/dev/ttyACM0", "mqtts://argus:8883")
+
+
+@patch("dotbot.cli.gateway._run_gateway")
+def test_gateway_defaults_to_stdout_mode_no_mqtt(run):
+    result = CliRunner().invoke(gateway_cmd, ["--port", "/dev/ttyACM0"])
+    assert result.exit_code == 0, result.output
+    # mqtt_url is None → local-stdout mode.
+    run.assert_called_once_with("/dev/ttyACM0", None)

--- a/dotbot/tests/test_gateway.py
+++ b/dotbot/tests/test_gateway.py
@@ -15,28 +15,34 @@ from click.testing import CliRunner
 from dotbot.cli.gateway import cmd as gateway_cmd
 
 
-def test_gateway_help_mentions_stdout_mode():
+def test_gateway_help_mentions_print_and_broker():
     result = CliRunner().invoke(gateway_cmd, ["--help"])
     assert result.exit_code == 0
     assert "--port" in result.output
     assert "--mqtt-url" in result.output
-    # The no-broker default behaviour is documented.
-    assert "stdout" in result.output.lower()
+    assert "--no-print" in result.output
 
 
 @patch("dotbot.cli.gateway._run_gateway")
-def test_gateway_forwards_port_and_mqtt_url(run):
+def test_gateway_forwards_port_mqtt_url_and_print(run):
     result = CliRunner().invoke(
         gateway_cmd,
         ["--port", "/dev/ttyACM0", "--mqtt-url", "mqtts://argus:8883"],
     )
     assert result.exit_code == 0, result.output
-    run.assert_called_once_with("/dev/ttyACM0", "mqtts://argus:8883")
+    # print defaults to True.
+    run.assert_called_once_with("/dev/ttyACM0", "mqtts://argus:8883", True)
 
 
 @patch("dotbot.cli.gateway._run_gateway")
-def test_gateway_defaults_to_stdout_mode_no_mqtt(run):
+def test_gateway_no_mqtt_defaults_print_on(run):
     result = CliRunner().invoke(gateway_cmd, ["--port", "/dev/ttyACM0"])
     assert result.exit_code == 0, result.output
-    # mqtt_url is None → local-stdout mode.
-    run.assert_called_once_with("/dev/ttyACM0", None)
+    run.assert_called_once_with("/dev/ttyACM0", None, True)
+
+
+@patch("dotbot.cli.gateway._run_gateway")
+def test_gateway_no_print_flag(run):
+    result = CliRunner().invoke(gateway_cmd, ["--port", "/dev/ttyACM0", "--no-print"])
+    assert result.exit_code == 0, result.output
+    run.assert_called_once_with("/dev/ttyACM0", None, False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ build-backend = "hatchling.build"
 [tool.hatch.build]
 include = [
     "dotbot/frontend/*",
+    "dotbot/*.toml",
     "*.py"
 ]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ path = "utils/hooks/sdist.py"
 
 [project]
 name = "pydotbot"
-version = "0.29.0rc1"
+version = "0.29.0rc2"
 authors = [
     { name="Alexandre Abadie", email="alexandre.abadie@inria.fr" },
     { name="Theo Akbas", email="theo.akbas@inria.fr" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "uvicorn        >= 0.32.0",
     "websockets     >= 13.1.0",
     "gmqtt          >= 0.7.0",
-    "marilib-pkg    >= 0.9.0rc2",
+    "marilib-pkg    >= 0.9.0rc3",
     "pydotbot-utils >= 0.3.0",
     "toml           >= 0.10.2",
 ]


### PR DESCRIPTION
First slice of the controller-CLI redesign (plan: locked 2026-05-30).
Replaces the controller's transport mess with one discriminated
connection string, and adds the host-side `dotbot gateway` bridge.

## Controller surface

Gone: `-a/--adapter` (5 values), `-H/-P/-T`, `-p/-b`, `--network-id`.
New:

| flag | value |
|---|---|
| `--conn` / `-n` / `--connection` | `mqtts://host:port` \| `/dev/ttyACM0` \| `simulator` |
| `--swarm-id` / `-s` | hex; **required for mqtt**, ignored for serial/sim |
| `--dotbot` / `--sailbot` | which robot `--conn simulator` fakes |

```bash
dotbot controller --conn mqtts://argus:8883 --swarm-id 1234 -w
dotbot controller --conn /dev/ttyACM0 -w
dotbot controller --conn simulator -w
```

The internal `adapter` enum (`cloud`/`edge`/`dotbot-simulator`/…) stays
an implementation detail the CLI never exposes — `dotbot/cli/_conn.py`
parses the connection string and `controller_app._conn_to_settings`
maps it onto the existing settings. TOML config uses `conn` / `swarm_id`.

## `dotbot gateway`

New subcommand — a thin re-mount of marilib's `mari-edge`. Bridges a
UART gateway to an MQTT broker; with no `--mqtt-url` it prints received
frames to stdout (local debug mode, zero broker infra).

```bash
dotbot gateway --port /dev/ttyACM0 --mqtt-url mqtts://argus:8883
dotbot gateway --port /dev/ttyACM0    # local-stdout debug
```

## Broker auth

Credentials come from `DOTBOT_MQTT_USER` / `DOTBOT_MQTT_PASS` in the
environment (keeps secrets out of the URL, shell history, and TOML).
**Cross-repo dependency:** actually authenticating needs a marilib
companion that adds `username`/`password` to `MQTTAdapter`. Until that
lands, set credentials are a no-op (anonymous connect, unchanged
behaviour) — the plumbing is in place and forwards only when set.

## No backwards-compat

Old flags + TOML keys removed outright (develop branch, frozen fork,
mid-revamp). `dotbot sim` keeps working (now routes through
`--conn simulator`).

## Tests / validation

242 unit tests pass. New: `test_conn.py` (parser), `test_controller_conn.py`
(`--conn` translation + env auth + conditional swarm-id),
`test_gateway.py`, plus updated `test_controller_app.py` /
`test_cli_dispatcher.py`. Live-checked the help surface, the guided
no-conn error, and the why-error on mqtt-without-swarm-id.

**Still needs hardware/MQTT validation** before ready: a real serial
gateway (`--conn /dev/ttyACM0`) and a real broker (`--conn mqtts://…`)
end-to-end. The simulator path (`--conn simulator`) is exercisable
without hardware.

Companion: DotBots/swarmit gets the same `--conn`/`--swarm-id` surface
(separate PR). A marilib PR for `MQTTAdapter` username/password is the
remaining piece for env auth to take effect.