### PR TITLE
dotbot/cli: reorganize the top level into fw/device/swarm/run namespaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Python control plane for DotBots. Serial / cloud / edge adapters talk to a DotBot gateway (often via Mari → marilib); a FastAPI REST + WebSocket server exposes state; a React web UI provides joystick/map/lighthouse-position visualization. Ships a unified `dotbot` CLI (`dotbot controller`, `dotbot swarm`, `dotbot calibrate-lh2`, `dotbot fw`, `dotbot make`, `dotbot demo`, `dotbot keyboard`, `dotbot joystick`, ...) plus DotBot/SailBot simulators. Legacy entry points `dotbot-controller` / `dotbot-keyboard` / `dotbot-joystick` are kept as backwards-compat aliases for one deprecation cycle.
+Python control plane for DotBots. Serial / cloud / edge adapters talk to a DotBot gateway (often via Mari → marilib); a FastAPI REST + WebSocket server exposes state; a React web UI provides joystick/map/lighthouse-position visualization. Ships a unified `dotbot` CLI whose top level is four object-namespaces: `fw` (firmware artifacts: build/fetch/list/make), `device` (one cabled device: flash/info), `swarm` (the fleet over the air), and `run` (host-side processes you launch — `dotbot run controller`, `run gateway`, `run sim`, `run lh2-calibration`, `run demo`, `run keyboard`, `run joystick`), plus DotBot/SailBot simulators. The `dotbot` dispatcher is the only console script — there are no per-command `dotbot-*` binaries.
 
 This is the most active repo in the ecosystem (187 commits in last 90 days as of 2026-05-05).
 
@@ -16,7 +16,7 @@ This is the most active repo in the ecosystem (187 commits in last 90 days as of
 ## Entry points
 
 - `dotbot/cli/main.py` — unified `dotbot` Click group (lazy subcommand loader)
-- `dotbot/controller_app.py` — `dotbot controller` subcommand backend; wires adapters and settings
+- `dotbot/controller_app.py` — `dotbot run controller` subcommand backend; wires adapters and settings
 - `dotbot/controller.py:1` — 737-line `Controller` class; central object
 - `dotbot/frontend/src/App.tsx` — React UI root
 
@@ -24,12 +24,14 @@ This is the most active repo in the ecosystem (187 commits in last 90 days as of
 
 ```bash
 pip install pydotbot                         # or `pip install -e .`
-dotbot --help               # unified dispatcher
-dotbot controller --help    # start the controller
-dotbot swarm --help         # swarm orchestration (optional: pip install pydotbot[swarm])
-dotbot calibrate-lh2 --help # LH2 calibration (optional: pip install pydotbot[calibrate])
-dotbot fw --help            # bare firmware build/clean/targets/artifacts
-dotbot demo --list          # built-in research demos
+dotbot --help                    # unified dispatcher: fw / device / swarm / run
+dotbot fw --help                 # firmware artifacts: build / fetch / list / make
+dotbot device --help             # one cabled device: flash an app/role, read info
+dotbot swarm --help              # the fleet over the air (optional: pip install pydotbot[swarm])
+dotbot run --help                # host-side processes (controller, gateway, sim, ...)
+dotbot run controller --help     # start the controller
+dotbot run lh2-calibration --help  # LH2 calibration (optional: pip install pydotbot[calibrate])
+dotbot run demo --list           # built-in research demos
 
 # Tests / lint / build
 tox                                          # envs: tests, check, cli, web=npm run lint, doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,25 +13,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   sim, testbed ops, calibration, demos, keyboard/joystick) under one
   command. Subcommand modules are loaded lazily so `dotbot --help` stays
   cheap.
-- `dotbot demo` discoverable launcher; `dotbot demo qr` runs the qrkey
-  phone-bridge demo.
+- `dotbot run demo` discoverable launcher; `dotbot run demo qr` runs the
+  qrkey phone-bridge demo.
 - `dotbot fw` mock surface (scaffold/build/flash subcommands; placeholder
   for the firmware-developer workflow).
 - **Vendored `dotbot-provision`** into `dotbot/provision/`. All five
   subcommands available as `dotbot testbed provision <fetch|flash|
   flash-hex|read-config|flash-bringup>`.
 - **Vendored `dotbot-lh2-calibration` (Python side)** into
-  `dotbot/calibration/`. Surfaced as `dotbot calibrate-lh2` with
+  `dotbot/calibration/`. Surfaced as `dotbot run lh2-calibration` with
   two subcommands:
   - `collect` — runs the Textual TUI (default — bare
-    `dotbot calibrate-lh2` invokes this for muscle memory)
+    `dotbot run lh2-calibration` invokes this for muscle memory)
   - `apply <path>` — write the saved calibration as a C header to
     `<path>` (replaces the previous `dotbot-calibration-exporter`;
     today the only consumer is the swarmit secure bootloader which
     `#include`s the file at compile time)
   The C firmware in the `dotbot-lh2-calibration` repo is unchanged.
   Future OTA / swarm-wide counterparts (`collect` over MQTT,
-  `apply` as OTA push) will live under `dotbot testbed
+  `apply` as OTA push) will live under `dotbot swarm
   calibrate-lh2`.
 - Calibration records are now saved as timestamped, schema-versioned
   TOML files (`~/.dotbot/calibration-<UTC timestamp>.toml`) carrying
@@ -54,6 +54,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **Breaking — CLI reorganized into four object-namespaces.** The top
+  level is now exactly `fw` (firmware artifacts), `device` (one cabled
+  device), `swarm` (the fleet), and `run` (host-side processes). The flat
+  process verbs moved under `run`: `dotbot controller` → `dotbot run
+  controller`, and likewise `gateway` / `sim` / `demo` / `keyboard` /
+  `joystick`; `dotbot calibrate-lh2` → `dotbot run lh2-calibration`. The
+  Makefile escape hatch moved from `dotbot make` to `dotbot fw make`.
+  `run` subcommands are still loaded lazily, so `dotbot run --help` stays
+  cheap.
 - The qrkey integration moved from `dotbot/qrkey.py` to
   `dotbot/examples/qrkey_demo/`. The demo is now a separate process that
   consumes the controller's REST API — the controller stays agnostic to
@@ -66,7 +75,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Removed
 
 - `dotbot-qrkey` console script — use `python -m dotbot.examples.qrkey_demo`
-  or `dotbot demo qr` instead.
+  or `dotbot run demo qr` instead.
 - `dotbot-edge-gateway` console script — the referenced module
   `dotbot.edge_gateway_app` never existed; the entry was silently broken.
 - `pin_code` tox env — referenced `dotbot/pin_code_ui/` which never
@@ -75,12 +84,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   (folded into the `dotbot` package). The standalone PyPI packages are
   scheduled for deprecation releases that point users at `pip install
   dotbot[provision]` / `pip install dotbot[calibrate]`.
+- `dotbot-controller`, `dotbot-keyboard`, and `dotbot-joystick` console
+  scripts — removed outright (no longer aliased). Use `dotbot run
+  controller` / `dotbot run keyboard` / `dotbot run joystick`.
 
 ### Deprecated
 
-- `dotbot-controller`, `dotbot-keyboard`, and `dotbot-joystick` console
-  scripts remain working as backwards-compat aliases for one deprecation
-  cycle. Prefer `dotbot <subcommand>` for new code.
 - The standalone `dotbot-provision` and `dotbot-lh2-calibration` PyPI
   packages will issue `DeprecationWarning` on their next release and
   point users at `pip install dotbot[provision]` /

--- a/README.md
+++ b/README.md
@@ -13,10 +13,21 @@ thousands, for research and education.
 
 The firmware for the DotBots can be found [here][dotbot-firmware-repo].
 
+## Prerequisites
+
+Software to install (as needed):
+- Python ≥ 3.11 - ensure you have pip also installed
+- [nRF Command Line Tools](https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools) (`nrfjprog`), for commands such as `dotbot device flash`
+- [SEGGER Embedded Studio](https://www.segger.com/products/development-tools/embedded-studio/), for commands such as `dotbot fw build`
+
+Minimal hardware setup:
+- DotBot v3, as well as a USB-C cable and a barrel-jack charger (2.5 mm, 6–18 V, 5/10 A)
+- nRF5340-DK to use as gateway, as well as a micro-USB cable
+
 ## Install
 
 ```bash
-pip install --pre 'pydotbot[all]'   # --pre while 0.29 is in pre-release
+pip install --pre 'pydotbot[swarm]'   # --pre while 0.29 is in pre-release
 git clone --recurse-submodules --branch develop https://github.com/DotBots/DotBot-firmware.git
 ```
 
@@ -26,9 +37,9 @@ git clone --recurse-submodules --branch develop https://github.com/DotBots/DotBo
 $ dotbot --help
 Usage: dotbot [OPTIONS] COMMAND [ARGS]...
 
-  Control DotBots. Four namespaces: firmware artifacts (fw), one connected
-  device (device), the fleet over the air (swarm), and host-side processes
-  you launch (run).
+  One CLI for the whole DotBot workflow: build and flash firmware, program and
+  control a single robot, and run experiments over the air across a swarm -
+  from one bot to a thousand.
 
 Commands:
   fw      Firmware artifacts (no hardware): build / fetch / list / make.
@@ -74,9 +85,9 @@ To operate as a swarm, we need to fetch some firmware, and setup a configuration
 
 ```bash
 # pull the pre-compiled firmwares from a release
-dotbot fw fetch -f 0.8.0rc1
+dotbot fw fetch -f 0.8.0rc1  # or build yourself with: dotbot fw artifacts --sandbox
 # configure where to connect and which swarm
-cat > tb-config.toml <<'EOF'
+cat > swarm-config.toml <<'EOF'
 conn = "mqtts://argus.paris.inria.fr:8883"
 swarm_id = "1234"
 EOF
@@ -106,14 +117,14 @@ dotbot run gateway -m mqtts://argus.paris.inria.fr:8883 -p /dev/cu.usbmodem00105
 You can flash as many dotbots as you want, all at once! First, how about making them spinnnn 🔄 🔄
 
 ```bash
-dotbot swarm -c tb-config.toml flash ./artifacts/spin-sandbox-dotbot-v3.bin -ys  # flash the whole fleet with a simple spinning app
+dotbot swarm -c swarm-config.toml flash ./artifacts/spin-sandbox-dotbot-v3.bin -ys  # flash the whole fleet with a simple spinning app
 ```
 
 Then, flash another experiment:
 
 ```bash
-dotbot swarm -c tb-config.toml stop  # ensure all robots are in bootloader
-dotbot swarm -c tb-config.toml flash ./artifacts/dotbot-sandbox-dotbot-v3.bin -ys  # this firmware allows bots to be remote-controlled
+dotbot swarm -c swarm-config.toml stop  # ensure all robots are in bootloader
+dotbot swarm -c swarm-config.toml flash ./artifacts/dotbot-sandbox-dotbot-v3.bin -ys  # this firmware allows bots to be remote-controlled
 ```
 
 Observe and control your swarm from a web interface:
@@ -126,6 +137,8 @@ dotbot run controller --conn mqtts://argus.paris.inria.fr:8883 --swarm-id 1234 -
 
 Follow this section if you want your robots to have localization information.
 You will need at least one Lighthouse 2 base station.
+
+Note: this section needs the calibration extra — `pip install --pre 'pydotbot[calibrate]'`.
 
 ### collect calibration
 
@@ -140,8 +153,8 @@ dotbot run lh2-calibration collect -p /dev/tty.usbmodem0007745943981 -d 200  # c
 Then, update the swarm with a new calibration:
 
 ```bash
-dotbot swarm -c tb-config.toml stop  # ensure all robots are in bootloader
-dotbot swarm -c tb-config.toml calibrate-lh2 ~/.dotbot/calibration-2026-05-26T14-00-36Z.toml
+dotbot swarm -c swarm-config.toml stop  # ensure all robots are in bootloader
+dotbot swarm -c swarm-config.toml calibrate-lh2 ~/.dotbot/calibration-2026-05-26T14-00-36Z.toml
 ```
 
 Now your bots should be reporting their `(x, y)` location!

--- a/README.md
+++ b/README.md
@@ -6,35 +6,24 @@
 
 # PyDotBot
 
-This package contains a complete environment for controlling and visualizing
-[DotBots](http://www.dotbots.org).
+This package contains a complete environment for using [DotBots](http://www.dotbots.org).
 
-The DotBots hardware design can be found [here (PCB)][dotbot-pcb-repo].
-The firmware running on the DotBots can be found [here][dotbot-firmware-repo].
+The DotBot is a small wireless wheeled robot, built to operate in swarms of
+thousands, for research and education.
 
-This package can also be used to control devices running the SailBot firmware
-application.
+The firmware for the DotBots can be found [here][dotbot-firmware-repo].
 
-![DotBots controller overview][pydotbot-overview]
+## Install
 
-## Installation
-
-Run `pip install pydotbot`
-
-## Setup
-
-Flash the required firmwares on the DotBots and gateway board (use an
-nRF52833DK/nRF52840DK/nrf5340DK board as gateway), as explained in
-[the DotBots firmware repository][dotbot-firmware-repo].
+```bash
+pip install --pre 'pydotbot[all]'   # --pre while 0.29 is in pre-release
+git clone --recurse-submodules --branch develop https://github.com/DotBots/DotBot-firmware.git
+```
 
 ## Usage
 
-A single `dotbot` CLI dispatches to every workflow. The top level is four
-namespaces, each one *kind of thing* — firmware artifacts, one connected
-device, the fleet, and host-side processes you launch:
-
 ```
-dotbot --help
+$ dotbot --help
 Usage: dotbot [OPTIONS] COMMAND [ARGS]...
 
   Control DotBots. Four namespaces: firmware artifacts (fw), one connected
@@ -48,8 +37,116 @@ Commands:
   run     Host-side processes: controller, gateway, sim, calibration, demos, teleop.
 ```
 
-Three groups are nouns you *manage*; `run` is the verb — the long-running
-software you launch on your own computer:
+## Quickstart - one bot
+
+Build and flash firmware for a single dotbot:
+
+```bash
+# build the bare dotbot app into ./artifacts/ (needs SEGGER Embedded Studio)
+dotbot fw artifacts --app dotbot
+# cable-flash it to the bot whose J-Link serial starts with 77
+dotbot device flash dotbot -s 77
+```
+
+Now, build and flash the gateway to connect to a robot.
+The gateway is a dev board (e.g. an nRF52840-DK) plugged into your
+computer; it bridges the robot's radio to USB serial.
+
+```bash
+# build the gateway firmware for your DK board into ./artifacts/ (needs SEGGER Embedded Studio)
+dotbot fw artifacts --app dotbot_gateway -t nrf52840dk
+# cable-flash it to the DK whose J-Link serial starts with 10
+dotbot device flash dotbot_gateway -b nrf52840dk -s 10
+```
+
+With a gateway plugged into your computer, point the controller at it
+and open the web UI:
+
+```bash
+dotbot run controller --conn /dev/ttyACM0 -w  # serial gateway; no swarm-id needed
+```
+
+## Quickstart - a swarm
+
+### swarm setup
+
+To operate as a swarm, we need to fetch some firmware, and setup a configuration file:
+
+```bash
+# pull the pre-compiled firmwares from a release
+dotbot fw fetch -f 0.8.0rc1
+# configure where to connect and which swarm
+cat > tb-config.toml <<'EOF'
+conn = "mqtts://argus.paris.inria.fr:8883"
+swarm_id = "1234"
+EOF
+```
+
+The swarm mode also requires a special "sandbox" firmware in each dotbot.
+We also need a more powerful gateway firmware.
+Let's flash both:
+
+```bash
+dotbot device flash-gateway -n 1234 -s 10 -f 0.8.0rc1  # flash the gateway, setting its swarm id to 0x1234
+dotbot device flash-sandbox-host -n 1234 -s 77 -f 0.8.0rc1  # flash the sandbox firmware - do this on each dotbot
+```
+
+(`device flash-gateway` / `flash-sandbox-host` auto-fetch
+the release into `./artifacts/` if it isn't already there.)
+
+Now, run the gateway:
+
+```bash
+dotbot run gateway -m mqtts://argus.paris.inria.fr:8883 -p /dev/cu.usbmodem0010500324491
+```
+
+### swarm usage
+
+
+You can flash as many dotbots as you want, all at once! First, how about making them spinnnn 🔄 🔄
+
+```bash
+dotbot swarm -c tb-config.toml flash ./artifacts/spin-sandbox-dotbot-v3.bin -ys  # flash the whole fleet with a simple spinning app
+```
+
+Then, flash another experiment:
+
+```bash
+dotbot swarm -c tb-config.toml stop  # ensure all robots are in bootloader
+dotbot swarm -c tb-config.toml flash ./artifacts/dotbot-sandbox-dotbot-v3.bin -ys  # this firmware allows bots to be remote-controlled
+```
+
+Observe and control your swarm from a web interface:
+
+```bash
+dotbot run controller --conn mqtts://argus.paris.inria.fr:8883 --swarm-id 1234 -w  # will open a webpage at http://localhost:8000/PyDotBot/
+```
+
+## Quickstart - Lighthouse 2 localization
+
+Follow this section if you want your robots to have localization information.
+You will need at least one Lighthouse 2 base station.
+
+### collect calibration
+
+Learn more about the calibration setup (guide TODO).
+
+```bash
+# flash the LH2-calibration capture firmware to a cabled dotbot, then collect:
+dotbot device flash lh2_calibration -s 77
+dotbot run lh2-calibration collect -p /dev/tty.usbmodem0007745943981 -d 200  # collect data from a dotbot, use a square of side 20 cm
+```
+
+Then, update the swarm with a new calibration:
+
+```bash
+dotbot swarm -c tb-config.toml stop  # ensure all robots are in bootloader
+dotbot swarm -c tb-config.toml calibrate-lh2 ~/.dotbot/calibration-2026-05-26T14-00-36Z.toml
+```
+
+Now your bots should be reporting their `(x, y)` location!
+
+## More things you can do
 
 ```
 dotbot run controller            # control plane + REST/WS + dashboard
@@ -73,7 +170,7 @@ pip install pydotbot[all]        # all of the above
 ```
 
 Device flashing/provisioning (`dotbot device flash-…`) works out of the
-box — its `intelhex` dep is part of the core install. The LH2 calibration
+box. The LH2 calibration
 TUI/exporter (`dotbot run lh2-calibration`) keeps its heavyweight deps
 (textual / opencv-python) behind the `[calibrate]` extra so the core
 install stays lean.
@@ -82,7 +179,7 @@ install stays lean.
 
 Run `dotbot run controller --help` for the full flag list (`--conn`, MQTT,
 HTTP port, map size, etc.). By default the controller expects the serial
-port to be `/dev/ttyACM0` on Linux — use `--port` to override (e.g.
+port to be `/dev/ttyACM0` on Linux - use `--port` to override (e.g.
 `--port COM3` on Windows).
 
 With `--webbrowser`, a tab opens at
@@ -111,11 +208,15 @@ and set `network.http.http2.websockets` to `false`.
 
 ## Tests
 
-To run the tests, install [tox](https://pypi.org/project/tox/) and use it:
+To run the tests, run [tox](https://pypi.org/project/tox/):
 
 ```
 tox
 ```
+
+## License
+
+See `LICENSE` in each component repository.
 
 [ci-badge]: https://github.com/DotBots/PyDotBot/workflows/CI/badge.svg
 [ci-link]: https://github.com/DotBots/PyDotBot/actions?query=workflow%3ACI+branch%3Amain
@@ -127,6 +228,4 @@ tox
 [license-link]: https://github.com/DotBots/pydotbot/blob/main/LICENSE.txt
 [codecov-badge]: https://codecov.io/gh/DotBots/PyDotBot/branch/main/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/DotBots/PyDotBot
-[pydotbot-overview]: https://github.com/DotBots/PyDotBot/blob/main/dotbots.png?raw=True
 [dotbot-firmware-repo]: https://github.com/DotBots/DotBot-firmware
-[dotbot-pcb-repo]: https://github.com/DotBots/DotBot-hardware

--- a/README.md
+++ b/README.md
@@ -29,25 +29,40 @@ nRF52833DK/nRF52840DK/nrf5340DK board as gateway), as explained in
 
 ## Usage
 
-A single `dotbot` CLI dispatches to every workflow — controller,
-testbed ops, calibration, demos:
+A single `dotbot` CLI dispatches to every workflow. The top level is four
+namespaces, each one *kind of thing* — firmware artifacts, one connected
+device, the fleet, and host-side processes you launch:
 
 ```
 dotbot --help
 Usage: dotbot [OPTIONS] COMMAND [ARGS]...
 
-  Control DotBots: drive robots, run testbed experiments, calibrate, demos.
+  Control DotBots. Four namespaces: firmware artifacts (fw), one connected
+  device (device), the fleet over the air (swarm), and host-side processes
+  you launch (run).
 
 Commands:
-  controller  Start the controller (adapter + REST/WS + dashboard).
-  sim         Standalone simulator (equivalent to controller --adapter dotbot-simulator).
-  testbed     Testbed-side ops: provision, status, start/stop, OTA flash, monitor.
-  calibrate-lh2 LH2 calibration: capture, apply, export (serial-side / single device).
-  demo        Built-in research demos (qrkey phone bridge, ...).
-  fw          Firmware-developer workflow (scaffold/build/flash). Not yet implemented.
-  keyboard    Drive a DotBot from the keyboard (live).
-  joystick    Drive a DotBot from a joystick (live).
+  fw      Firmware artifacts (no hardware): build / fetch / list / make.
+  device  One connected device (cable/probe): flash an app/role, read info.
+  swarm   The fleet over the air: status, start/stop, OTA flash, monitor.
+  run     Host-side processes: controller, gateway, sim, calibration, demos, teleop.
 ```
+
+Three groups are nouns you *manage*; `run` is the verb — the long-running
+software you launch on your own computer:
+
+```
+dotbot run controller            # control plane + REST/WS + dashboard
+dotbot run gateway               # host-side UART <-> MQTT bridge
+dotbot run sim                   # ≡ run controller --conn simulator (no hardware)
+dotbot run lh2-calibration       # LH2 calibration workflow
+dotbot run demo qr               # built-in research demos
+dotbot run keyboard              # teleop a bot from the keyboard
+```
+
+Note the two "gateway"s the namespaces disambiguate: `dotbot device
+flash-gateway` flashes gateway *firmware* onto a board; `dotbot run
+gateway` runs the host-side bridge *process* that talks to it.
 
 Some subcommands need optional runtime deps:
 
@@ -59,12 +74,13 @@ pip install pydotbot[all]        # all of the above
 
 Device flashing/provisioning (`dotbot device flash-…`) works out of the
 box — its `intelhex` dep is part of the core install. The LH2 calibration
-TUI/exporter (`dotbot calibrate-lh2`) keeps its heavyweight deps (textual /
-opencv-python) behind the `[calibrate]` extra so the core install stays lean.
+TUI/exporter (`dotbot run lh2-calibration`) keeps its heavyweight deps
+(textual / opencv-python) behind the `[calibrate]` extra so the core
+install stays lean.
 
 ### Starting the controller
 
-Run `dotbot controller --help` for the full flag list (adapter, MQTT,
+Run `dotbot run controller --help` for the full flag list (`--conn`, MQTT,
 HTTP port, map size, etc.). By default the controller expects the serial
 port to be `/dev/ttyACM0` on Linux — use `--port` to override (e.g.
 `--port COM3` on Windows).
@@ -78,16 +94,16 @@ Use `--config-path` for a TOML config file:
 
 ```bash
 # Use settings from the config file
-dotbot controller --config-path config_sample.toml
-# Use config file but override port and adapter (simulator example)
-dotbot controller --config-path config_sample.toml -a dotbot-simulator
+dotbot run controller --config-path config_sample.toml
+# Use config file but override the connection (run a simulator instead)
+dotbot run controller --config-path config_sample.toml --conn simulator
 ```
 
 CLI flags override config-file values when both are provided.
 
-The legacy `dotbot-controller`, `dotbot-keyboard`, and `dotbot-joystick`
-console scripts remain as backwards-compatible aliases for one
-deprecation cycle. Prefer `dotbot <subcommand>` for new code.
+The `dotbot` dispatcher is the only console script — every workflow is a
+`dotbot <group> <verb>` subcommand. There are no per-command `dotbot-*`
+binaries.
 
 **Firefox users:**
 If the webapp is not working, press `Ctrl + L`, type `about:config`,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -117,7 +117,12 @@ html_theme_options = {
 
 # -- Options for linkcheck ---------------------------------------------
 
-linkcheck_ignore = [r"http://localhost:\d+/"]
+linkcheck_ignore = [
+    r"http://localhost:\d+/",
+    # nordicsemi.com's WAF returns 403 to the linkcheck bot; the link is valid
+    # for humans (the nRF Command Line Tools download linked from the README).
+    r"https://www\.nordicsemi\.com/",
+]
 
 # -- Options for autosummary/autodoc output -----------------------------------
 autosummary_generate = True

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -36,12 +36,12 @@ DotBot(s).
   If using an nRF5340DK, you might see 2 TTY port, use the one with the lowest
   id.
 
-3. From a terminal window (or powershell on Windows), run `dotbot controller`
+3. From a terminal window (or powershell on Windows), run `dotbot run controller`
   with the TTY port you identified above and the `--webbrowser` flag to
   automatically open the web client:
 
 ```
-dotbot controller --port <tty port> --webbrowser
+dotbot run controller --port <tty port> --webbrowser
 ```
 
 At this point, if the DotBot is powered on with fully charged batteries, you
@@ -84,7 +84,7 @@ Welcome to the DotBots controller (version: 0.xx).
     the DotBot to move
   - by using the color selector in the UI
 
-5. In a separate command window, launch `dotbot keyboard`:
+5. In a separate command window, launch `dotbot run keyboard`:
 ```
 Welcome to the DotBots keyboard interface (version: 0.16).
 2023-12-08T10:07:32.597536Z [info     ] Controller initialized         [pydotbot] context=dotbot.keyboard

--- a/doc/mqtt.md
+++ b/doc/mqtt.md
@@ -42,7 +42,7 @@ change and recomputes (or rederive) their key/topic accordingly.
 ## Prerequisites
 
 Make sure you already followed the [getting started](getting_started) page and
-have a functional setup with `dotbot controller` running and connected to a
+have a functional setup with `dotbot run controller` running and connected to a
 nRF DK gateway.
 
 To interact with the MQTT broker, you will use a Python script that require
@@ -65,7 +65,7 @@ pip install cryptography joserfc paho-mqtt requests
 Running the controller is as easy as running the following command:
 
 ```
-dotbot controller
+dotbot run controller
 ```
 
 The logs should contain information about the MQTT broker connection and the

--- a/doc/rest.md
+++ b/doc/rest.md
@@ -1,10 +1,10 @@
 # REST
 
-While connected to a DotBot gateway, the `dotbot controller`
+While connected to a DotBot gateway, the `dotbot run controller`
 application provides a REST server to send commands to and receive information
 from connected DotBots.
 
-The REST API is documented in the running `dotbot controller` application itself
+The REST API is documented in the running `dotbot run controller` application itself
 at [http://localhost:8000/api](http://localhost:8000/api). This page also allows
 you to play with the API directly from the browser.
 
@@ -18,7 +18,7 @@ you to play with the API directly from the browser.
 ## Prerequisites
 
 Make sure you already followed the [getting started](getting_started) page and
-have a functional setup with `dotbot controller` running and connected to a
+have a functional setup with `dotbot run controller` running and connected to a
 nRF DK gateway.
 
 To interact with the REST API, you will use the Python
@@ -66,7 +66,7 @@ If a DotBot is connected, this script should give an output similar to:
 ]
 ```
 
-This is a list of all DotBots connected to the `dotbot controller`. In the
+This is a list of all DotBots connected to the `dotbot run controller`. In the
 example above, there is only one DotBot connected.
 The 8-byte `address` uniquely identifies a DotBot in the controller. The
 `status` indicates whether the DotBot is `Active` (value=0, the DotBot has been

--- a/dotbot/cli/_conn.py
+++ b/dotbot/cli/_conn.py
@@ -3,7 +3,7 @@
 
 """Parse a `--conn` connection string into a typed result.
 
-`dotbot controller --conn CONNECTION` takes one discriminated
+`dotbot run controller --conn CONNECTION` takes one discriminated
 connection string whose *form* selects the kind of connection - the
 `git remote` / `docker -H` / MAVSDK `add_any_connection()` pattern:
 

--- a/dotbot/cli/_fw_helpers.py
+++ b/dotbot/cli/_fw_helpers.py
@@ -42,6 +42,8 @@ from typing import Iterable, Optional
 import click
 import toml
 
+from dotbot.firmware.boards import BOARDS
+
 # Glob used to discover SES installs on macOS. Picks the lexicographically
 # largest match (e.g. "Studio 8.30" beats "Studio 8.22a"), which is good
 # enough as a fallback when the user hasn't set SEGGER_DIR or written
@@ -53,26 +55,12 @@ _SEGGER_MACOS_GLOB = "/Applications/SEGGER/SEGGER Embedded Studio*"
 # CALIBRATION_PATH).
 _CONFIG_PATH = Path.home() / ".dotbot" / "config.toml"
 
-# BUILD_TARGET values handled by DotBot-firmware's Makefile (bare path).
-# Mirrors the explicit branches in the Makefile; an unrecognized target
-# falls through to the catch-all `find apps/` rule which produces opaque
-# SES errors, so we validate up-front.
-BARE_TARGETS = frozenset(
-    {
-        "dotbot-v1",
-        "dotbot-v2",
-        "dotbot-v3",
-        "nrf52833dk",
-        "nrf52840dk",
-        "nrf5340dk-app",
-        "nrf5340dk-net",
-        "sailbot-v1",
-        "freebot-v1.0",
-        "lh2-mini-mote",
-        "xgo-v1",
-        "xgo-v2",
-    }
-)
+# BUILD_TARGET / flashable board names. Single source of truth is the board
+# table in `dotbot.firmware.boards` (which also carries each board's nrfjprog
+# family + core) — so a valid build target and a flashable board can't drift
+# apart. An unrecognized target falls through to the Makefile's catch-all
+# `find apps/` rule (opaque SES errors), so we validate up-front.
+BARE_TARGETS = frozenset(BOARDS)
 
 # BUILD_TARGET = "sandbox-" + BOARD for the sandbox path. Boards
 # supported by the SES `.emProject` files at the DotBot-firmware root.

--- a/dotbot/cli/_lazygroup.py
+++ b/dotbot/cli/_lazygroup.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""A Click group that lists subcommands eagerly but imports them on demand.
+
+Subcommands are declared as static `(cli-name, module path, short help)`
+triples. `--help` renders from the triples alone — cheap, no imports —
+and a subcommand's module is only imported when that subcommand is
+actually invoked. Each module must expose a `cmd` attribute (the Click
+command/group to mount).
+
+Why lazy: importing e.g. `dotbot.controller_app` pulls in `dotbot.server`,
+which mounts FastAPI StaticFiles at module load. That's fine for the
+`controller` subcommand but `dotbot run --help` shouldn't pay the cost (or
+fail when the frontend bundle isn't built). The root group and the `run`
+group both use this so the laziness holds at every level of the tree.
+"""
+
+import importlib
+from typing import Optional, Tuple
+
+import click
+
+# (cli-name, dotted module path, short help shown in the parent's --help)
+Subcommand = Tuple[str, str, str]
+
+
+class LazyGroup(click.Group):
+    """Click group resolving subcommands by importing their module on demand.
+
+    Pass the static subcommand table via the `subcommands=` keyword (it is
+    captured here and never forwarded to the base `click.Group`, which
+    would reject the unknown kwarg).
+    """
+
+    def __init__(self, *args, subcommands: Tuple[Subcommand, ...] = (), **kwargs):
+        super().__init__(*args, **kwargs)
+        self.lazy_subcommands: Tuple[Subcommand, ...] = tuple(subcommands)
+        self._help_index = {name: short for name, _, short in self.lazy_subcommands}
+        self._module_index = {name: mod for name, mod, _ in self.lazy_subcommands}
+
+    def list_commands(self, ctx):
+        return [name for name, _, _ in self.lazy_subcommands]
+
+    def get_command(self, ctx, cmd_name) -> Optional[click.Command]:
+        module_path = self._module_index.get(cmd_name)
+        if module_path is None:
+            return None
+        module = importlib.import_module(module_path)
+        command = getattr(module, "cmd", None)
+        if command is None:
+            raise RuntimeError(
+                f"{module_path} is registered as the `{cmd_name}` subcommand "
+                "but does not expose a `cmd` attribute."
+            )
+        return command
+
+    def format_commands(self, ctx, formatter):
+        """Render the command list from the static table.
+
+        Overriding this is what keeps `--help` from importing every
+        subcommand module just to read its one-line help — that would
+        defeat the lazy load.
+        """
+        rows = [(name, self._help_index[name]) for name, _, _ in self.lazy_subcommands]
+        if rows:
+            with formatter.section("Commands"):
+                formatter.write_dl(rows)

--- a/dotbot/cli/calibrate.py
+++ b/dotbot/cli/calibrate.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""`dotbot calibrate-lh2` — LH2 calibration (serial side).
+"""`dotbot run lh2-calibration` — LH2 calibration (serial side).
 
 Native subgroup mounting the vendored `dotbot.calibration` package.
 Serial-attached, single-device operations. OTA / swarm-wide
-counterparts will live under `dotbot testbed calibrate-lh2`.
+counterparts will live under `dotbot swarm calibrate-lh2`.
 
 Subcommands:
 
@@ -31,8 +31,8 @@ def _run_tui(ctx: click.Context) -> None:
         from dotbot.calibration.cli import main as _tui_main
     except ImportError as exc:
         click.echo(
-            "`dotbot calibrate-lh2 collect` needs the calibration runtime "
-            "deps (opencv-python, textual).\n"
+            "`dotbot run lh2-calibration collect` needs the calibration "
+            "runtime deps (opencv-python, textual).\n"
             "Install with:  pip install dotbot[calibrate]",
             err=True,
         )
@@ -46,7 +46,7 @@ def _run_tui(ctx: click.Context) -> None:
 
 
 @click.group(
-    name="calibrate-lh2",
+    name="lh2-calibration",
     help="LH2 calibration: capture, apply, export (serial-side / single device).",
     invoke_without_command=True,
 )
@@ -54,9 +54,9 @@ def _run_tui(ctx: click.Context) -> None:
 def cmd(ctx: click.Context) -> None:
     if ctx.invoked_subcommand is not None:
         return
-    # Bare `dotbot calibrate-lh2` with no subcommand defaults to collect,
-    # matching the pre-rename `dotbot calibrate` behavior so muscle
-    # memory still works.
+    # Bare `dotbot run lh2-calibration` with no subcommand defaults to
+    # collect — the most common action — so it works without recalling
+    # the subcommand name.
     _run_tui(ctx)
 
 
@@ -81,7 +81,7 @@ def _collect(ctx: click.Context) -> None:
         "Write the saved calibration as a C header to PATH. Today the "
         "consumer is the swarmit secure bootloader (#includes the file "
         "at compile time). OTA / runtime equivalents will live under "
-        "`dotbot testbed calibrate-lh2 apply`."
+        "`dotbot swarm calibrate-lh2 apply`."
     ),
 )
 @click.argument(
@@ -94,8 +94,8 @@ def _apply(path: str) -> None:
         from dotbot.calibration.lighthouse2 import LighthouseManager
     except ImportError as exc:
         click.echo(
-            "`dotbot calibrate-lh2 apply` needs the calibration runtime "
-            "deps.\nInstall with:  pip install dotbot[calibrate]",
+            "`dotbot run lh2-calibration apply` needs the calibration "
+            "runtime deps.\nInstall with:  pip install dotbot[calibrate]",
             err=True,
         )
         click.echo(f"(import error was: {exc})", err=True)
@@ -107,7 +107,7 @@ def _apply(path: str) -> None:
         click.echo(
             "No saved calibration found at "
             f"{lh2_manager.calibration_output_path}.\n"
-            "Run `dotbot calibrate-lh2 collect` first.",
+            "Run `dotbot run lh2-calibration collect` first.",
             err=True,
         )
         sys.exit(1)

--- a/dotbot/cli/controller.py
+++ b/dotbot/cli/controller.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""`dotbot controller` — start the controller + REST/WS + dashboard.
+"""`dotbot run controller` — start the controller + REST/WS + dashboard.
 
 Today this re-mounts the existing `dotbot.controller_app:main` Click
 command verbatim. A future refactor will extract the engine from the
@@ -10,7 +10,7 @@ controller monolith.
 
 from dotbot.controller_app import main as _controller_main
 
-# Re-export the existing command without mutation. The dispatcher
+# Re-export the existing command without mutation. The `run` group
 # registers it under name="controller"; Click's usage formatter uses
 # that lookup name, not cmd.name, so we don't need to rewrite it.
 cmd = _controller_main

--- a/dotbot/cli/demo.py
+++ b/dotbot/cli/demo.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""`dotbot demo` — discoverable launcher for built-in research demos.
+"""`dotbot run demo` — discoverable launcher for built-in research demos.
 
 Demos live in `dotbot/examples/`. Each demo consumes the controller's
 REST/WS API and runs as a separate process — the controller stays
@@ -34,7 +34,7 @@ def cmd(ctx, list_demos):
             short = (sub.help or "").splitlines()[0] if sub.help else ""
             click.echo(f"  {name:<12} {short}")
         click.echo("")
-        click.echo("Run one with: dotbot demo <name> [OPTIONS]")
+        click.echo("Run one with: dotbot run demo <name> [OPTIONS]")
         ctx.exit(0)
 
 

--- a/dotbot/cli/device.py
+++ b/dotbot/cli/device.py
@@ -10,9 +10,8 @@ provisioning state. The fleet/OTA equivalents live under `dotbot swarm`;
 firmware ARTIFACT build/fetch/list live under `dotbot fw`.
 
 NOTE: `dotbot device flash-gateway` FLASHES gateway firmware onto a board
-over the cable. The top-level `dotbot gateway` is something else entirely
-— the host-side UART<->MQTT bridge process. Different verbs, different
-objects.
+over the cable. `dotbot run gateway` is something else entirely — the
+host-side UART<->MQTT bridge process. Different verbs, different objects.
 """
 
 from pathlib import Path
@@ -144,7 +143,7 @@ def flash_gateway(network_id, fw_version, sn_starting_digits):
 
     Flashes the Mari gateway firmware (both cores) + writes the network
     identity. Auto-fetches the release if absent. (To run the host-side
-    UART<->MQTT bridge instead, use the top-level `dotbot gateway`.)
+    UART<->MQTT bridge instead, use `dotbot run gateway`.)
     """
     from dotbot.firmware.flash import flash_role, normalize_network_id
 

--- a/dotbot/cli/device.py
+++ b/dotbot/cli/device.py
@@ -51,7 +51,10 @@ def _looks_like_path(value: str) -> bool:
     "-b",
     default="dotbot-v3",
     show_default=True,
-    help="Board the app targets (used to resolve <app>-<board> in ./artifacts/).",
+    help=(
+        "Target board: selects the chip family + core to flash (nRF52 vs "
+        "nRF5340 app/net) and resolves <app>-<board> in ./artifacts/."
+    ),
 )
 @click.option("--sandbox", is_flag=True, help="Resolve the sandbox-app flavor (.bin).")
 @click.option(
@@ -62,11 +65,12 @@ def _looks_like_path(value: str) -> bool:
     show_default=True,
 )
 def flash(app, sn_starting_digits, board, sandbox, config):
-    """Flash an application image to a provisioned device's app core.
+    """Flash a firmware image to one cabled device (whole-chip program).
 
-    APP is an app name (resolved against ./artifacts/, building from
-    source if needed) or an explicit `.hex`/`.bin` file path. The device
-    must already carry the sandbox host (`dotbot device flash-sandbox-host`).
+    APP is an app name (resolved against ./artifacts/, building from source
+    if needed) or an explicit `.hex`/`.bin` file path. `--board` selects the
+    chip family + core to program (see `dotbot fw targets`); no sandbox host
+    is required.
     """
     from dotbot.firmware.flash import flash_app_image
 
@@ -77,7 +81,7 @@ def flash(app, sn_starting_digits, board, sandbox, config):
             raise click.ClickException(f"Firmware image not found: {image}")
     else:
         image = resolve_app_artifact(app, board=board, config=config, sandbox=sandbox)
-    flash_app_image(image, sn_starting_digits=sn_starting_digits)
+    flash_app_image(image, board=board, sn_starting_digits=sn_starting_digits)
 
 
 def _fw_version_option(f):

--- a/dotbot/cli/fw.py
+++ b/dotbot/cli/fw.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""`dotbot fw` — firmware artifacts: build, fetch, list.
+"""`dotbot fw` — firmware artifacts: build, fetch, list, make.
 
 `fw` is the *artifacts* namespace — it produces or downloads firmware
 files. It never touches hardware: flashing a device lives under `fw`'s
@@ -15,6 +15,9 @@ sibling `dotbot device`, and OTA-flashing the fleet under `dotbot swarm`.
   the flat `<app>-<board>.hex` / `<app>-sandbox-<board>.bin` names.
 - `fetch` downloads a published release into `./artifacts/<version>/`.
 - `list` shows what's cached in `./artifacts/`.
+- `make` is the low-level escape hatch: it forwards arbitrary arguments
+  to `make` in the firmware repo (workspace-resolved SEGGER_DIR) for the
+  Makefile knobs `build` deliberately doesn't model.
 
 Only `artifacts` and `fetch` populate `./artifacts/`. The device-flash
 commands then auto-resolve their input, by *different* rules: `dotbot
@@ -56,7 +59,7 @@ _NOT_READY = (
         "Firmware artifacts: build (from source via SES), fetch (a release), "
         "list. Bare apps by default; `--sandbox` for TrustZone NS apps. "
         "Flashing lives under `dotbot device` (one board) and `dotbot swarm` "
-        "(the fleet). Need a Makefile knob? Use `dotbot make --help`."
+        "(the fleet). Need a Makefile knob? `dotbot fw make` forwards to `make`."
     ),
 )
 def cmd():
@@ -291,3 +294,11 @@ def new(name, template):  # pylint: disable=unused-argument
     """Scaffold a new firmware project (NOT IMPLEMENTED)."""
     click.echo(_NOT_READY.format(sub="new"), err=True)
     sys.exit(2)
+
+
+# The low-level Makefile escape hatch, mounted next to its high layer
+# `fw build`. Importing `make` here is cheap (no SES/firmware import at
+# module load), so it doesn't compromise the dispatcher's lazy loading.
+from dotbot.cli.make import cmd as _make_cmd  # noqa: E402
+
+cmd.add_command(_make_cmd)

--- a/dotbot/cli/gateway.py
+++ b/dotbot/cli/gateway.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""`dotbot gateway` — host-side Mari gateway bridge.
+"""`dotbot run gateway` — host-side Mari gateway bridge.
 
 Runs on whatever computer the gateway firmware is plugged into (a
 laptop for a starter setup, a Pi for a permanent install). Bridges UART
-HDLC frames to/from an MQTT broker, so a `dotbot controller --conn
+HDLC frames to/from an MQTT broker, so a `dotbot run controller --conn
 mqtts://…` can reach the swarm from anywhere.
 
 Thin re-mount of marilib's `mari-edge`: wraps a `MarilibEdge` with a
@@ -30,7 +30,7 @@ import click
 def _run_gateway(port, mqtt_url, do_print):  # pragma: no cover - needs a gateway
     """Construct a MarilibEdge bridge and pump it until interrupted.
 
-    Imports marilib lazily so `dotbot gateway --help` is cheap and the
+    Imports marilib lazily so `dotbot run gateway --help` is cheap and the
     command is importable without a serial port present.
     """
     from marilib.communication_adapter import MQTTAdapter, SerialAdapter
@@ -66,7 +66,7 @@ def _run_gateway(port, mqtt_url, do_print):  # pragma: no cover - needs a gatewa
         metrics_probe_period=0,
     )
     where = mqtt_url if mqtt_url else "(no broker — print only)"
-    click.echo(f"dotbot gateway: {port} <-> {where}", err=True)
+    click.echo(f"dotbot run gateway: {port} <-> {where}", err=True)
     try:
         while True:
             mari.update()

--- a/dotbot/cli/joystick.py
+++ b/dotbot/cli/joystick.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""`dotbot joystick` — drive a bot live from a USB joystick."""
+"""`dotbot run joystick` — drive a bot live from a USB joystick."""
 
 from dotbot.joystick import main as _joystick_main
 

--- a/dotbot/cli/keyboard.py
+++ b/dotbot/cli/keyboard.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""`dotbot keyboard` — drive a bot live from the keyboard."""
+"""`dotbot run keyboard` — drive a bot live from the keyboard."""
 
 from dotbot.keyboard import main as _keyboard_main
 

--- a/dotbot/cli/main.py
+++ b/dotbot/cli/main.py
@@ -59,9 +59,9 @@ _SUBCOMMANDS = (
     cls=LazyGroup,
     subcommands=_SUBCOMMANDS,
     help=(
-        "Control DotBots. Four namespaces: firmware artifacts (fw), one "
-        "connected device (device), the fleet over the air (swarm), and "
-        "host-side processes you launch (run)."
+        "One CLI for the whole DotBot workflow: build and flash firmware, "
+        "program and control a single robot, and run experiments over the air "
+        "across a swarm - from one bot to a thousand."
     ),
 )
 @click.version_option(

--- a/dotbot/cli/main.py
+++ b/dotbot/cli/main.py
@@ -1,112 +1,68 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Root `dotbot` Click group with lazy subcommand loading.
+"""Root `dotbot` Click group: four object-namespaces, lazily loaded.
 
-Each subcommand lives in its own module under `dotbot.cli.<name>` and
-exposes a `cmd` attribute. The root group lists subcommand names
-eagerly (so `dotbot --help` is cheap) but only imports a subcommand's
-module when the subcommand is actually invoked.
+The top level is exactly four groups, each one *kind of thing*:
 
-Why lazy: importing `dotbot.controller_app` pulls in `dotbot.server`
-which mounts FastAPI StaticFiles at module load — fine for the
-controller subcommand, but `dotbot fw --help` shouldn't pay that cost
-(or fail when the frontend bundle isn't built).
+  fw      — firmware artifacts (files in ./artifacts/, no hardware)
+  device  — one connected device (cable / probe)
+  swarm   — the fleet (radio / OTA)
+  run     — host-side processes (software you launch on your computer)
 
-Adding a new subcommand:
+Three are nouns (things you manage); `run` is the verb (the thing you do).
+`dotbot --help` teaches the system in four lines.
+
+Each group lives in its own module under `dotbot.cli.<name>` exposing a
+`cmd` attribute. The root lists the groups eagerly (so `dotbot --help` is
+cheap) but only imports a group's module when it's actually invoked — see
+`dotbot.cli._lazygroup.LazyGroup`.
+
+Adding a new top-level group:
   1. Create `dotbot/cli/<name>.py` exposing `cmd = click.Command(...)`.
-  2. Add an entry to `_SUBCOMMANDS` below: (cli-name, module path,
-     short help string shown in `dotbot --help`).
-  3. If the backend lives in an optional sibling package, use
+  2. Add a `(cli-name, module path, short help)` entry to `_SUBCOMMANDS`.
+  3. If the backend lives in an optional sibling package, wrap it with
      `dotbot.cli._lazy.lazy_subcommand` inside that module.
 """
-
-import importlib
-from typing import Optional, Tuple
 
 import click
 
 from dotbot import pydotbot_version
+from dotbot.cli._lazygroup import LazyGroup
 
 # (cli-name, dotted module path, short help shown by `dotbot --help`)
-_SUBCOMMANDS: Tuple[Tuple[str, str, str], ...] = (
+_SUBCOMMANDS = (
     (
-        "controller",
-        "dotbot.cli.controller",
-        "Start the controller (adapter + REST/WS + dashboard).",
-    ),
-    (
-        "sim",
-        "dotbot.cli.sim",
-        "Standalone simulator (equivalent to controller --conn simulator).",
-    ),
-    (
-        "gateway",
-        "dotbot.cli.gateway",
-        "Host-side Mari gateway bridge (UART <-> MQTT).",
+        "fw",
+        "dotbot.cli.fw",
+        "Firmware artifacts (no hardware): build / fetch / list / make.",
     ),
     (
         "device",
         "dotbot.cli.device",
-        "One connected device (cable): flash an app/role, read provisioning info.",
+        "One connected device (cable/probe): flash an app/role, read info.",
     ),
     (
         "swarm",
         "dotbot.cli.swarm",
-        "Fleet ops over the air: status, start/stop, OTA flash, monitor.",
+        "The fleet over the air: status, start/stop, OTA flash, monitor.",
     ),
     (
-        "calibrate-lh2",
-        "dotbot.cli.calibrate",
-        "LH2 calibration: capture, apply, export (serial-side / single device).",
+        "run",
+        "dotbot.cli.run",
+        "Host-side processes: controller, gateway, sim, calibration, demos, teleop.",
     ),
-    ("demo", "dotbot.cli.demo", "Built-in research demos (qrkey phone bridge, ...)."),
-    (
-        "fw",
-        "dotbot.cli.fw",
-        "Firmware artifacts: build / fetch / list (bare or --sandbox).",
-    ),
-    (
-        "make",
-        "dotbot.cli.make",
-        "Escape hatch: forward args to `make` in your DotBot-firmware checkout.",
-    ),
-    ("keyboard", "dotbot.cli.keyboard", "Drive a DotBot from the keyboard (live)."),
-    ("joystick", "dotbot.cli.joystick", "Drive a DotBot from a joystick (live)."),
 )
-
-_HELP_INDEX = {name: short for name, _, short in _SUBCOMMANDS}
-_MODULE_INDEX = {name: module_path for name, module_path, _ in _SUBCOMMANDS}
-
-
-class _LazyGroup(click.Group):
-    """Click group that resolves subcommands by importing on demand."""
-
-    def list_commands(self, ctx):
-        return [name for name, _, _ in _SUBCOMMANDS]
-
-    def get_command(self, ctx, cmd_name) -> Optional[click.Command]:
-        module_path = _MODULE_INDEX.get(cmd_name)
-        if module_path is None:
-            return None
-        module = importlib.import_module(module_path)
-        return module.cmd
-
-    def format_commands(self, ctx, formatter):
-        """Render `dotbot --help` from the static help-string table.
-
-        Overriding this avoids importing each subcommand module just to
-        pull its short help line — that would defeat the lazy load.
-        """
-        rows = [(name, _HELP_INDEX[name]) for name, _, _ in _SUBCOMMANDS]
-        if rows:
-            with formatter.section("Commands"):
-                formatter.write_dl(rows)
 
 
 @click.group(
-    cls=_LazyGroup,
-    help="Control DotBots: drive robots, run swarm experiments, calibrate, demos.",
+    cls=LazyGroup,
+    subcommands=_SUBCOMMANDS,
+    help=(
+        "Control DotBots. Four namespaces: firmware artifacts (fw), one "
+        "connected device (device), the fleet over the air (swarm), and "
+        "host-side processes you launch (run)."
+    ),
 )
 @click.version_option(
     version=pydotbot_version(),

--- a/dotbot/cli/make.py
+++ b/dotbot/cli/make.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""`dotbot make` — escape hatch to `make` in your DotBot-firmware checkout.
+"""`dotbot fw make` — escape hatch to `make` in your DotBot-firmware checkout.
 
-`dotbot fw build` (and `dotbot swarm fw build`) deliberately model only
+`dotbot fw build` deliberately models only
 the flags that matter for the daily edit/build loop: TARGET, `--app`,
 `--config`, `--rebuild`, `-v`. Anything else (PACKAGES_DIR_OPT, DOCKER
 overrides, `make doc`, custom CLANG_FORMAT_TYPE, …) is intentionally
@@ -40,8 +40,8 @@ from dotbot.cli._fw_helpers import resolve_firmware_repo, resolve_segger_dir
     help=(
         "Escape hatch: run `make` in your DotBot-firmware checkout with "
         "workspace-resolved SEGGER_DIR. Forwards all args verbatim. "
-        "Use this when `dotbot fw build` / `dotbot swarm fw build` "
-        "don't model the Makefile knob you need."
+        "Use this when `dotbot fw build` doesn't model the Makefile knob "
+        "you need."
     ),
 )
 @click.pass_context
@@ -49,11 +49,11 @@ def cmd(ctx):
     """Run `make` in the firmware repo. Examples:
 
     \b
-        dotbot make help
-        dotbot make list-targets
-        dotbot make BUILD_TARGET=dotbot-v3 BUILD_CONFIG=Debug
-        dotbot make BUILD_TARGET=dotbot-v3 PACKAGES_DIR_OPT="-packagesdir /opt/pkgs"
-        dotbot make docker BUILD_TARGET=sandbox-dotbot-v3
+        dotbot fw make help
+        dotbot fw make list-targets
+        dotbot fw make BUILD_TARGET=dotbot-v3 BUILD_CONFIG=Debug
+        dotbot fw make BUILD_TARGET=dotbot-v3 PACKAGES_DIR_OPT="-packagesdir /opt/pkgs"
+        dotbot fw make docker BUILD_TARGET=sandbox-dotbot-v3
     """
     repo = resolve_firmware_repo()
     segger = resolve_segger_dir()

--- a/dotbot/cli/run.py
+++ b/dotbot/cli/run.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""`dotbot run` — launch host-side processes (software on your computer).
+
+The fourth top-level namespace. `fw` / `device` / `swarm` are *nouns* —
+things you manage (artifacts, one board, the fleet). `run` is the *verb*:
+the long-running software you start on your own machine — the control
+plane, the gateway bridge, the simulator, the calibration workflow, the
+demos, the teleop drivers. Every reference CLI keeps "launch a process"
+as a top-level `run` (docker, cargo, ros2), so the asymmetry is correct,
+not an inconsistency.
+
+Note the two "gateway"s the namespaces disambiguate:
+`dotbot device flash-gateway` flashes gateway firmware onto a board;
+`dotbot run gateway` runs the host-side UART<->MQTT bridge process that
+talks to that board. Different objects, named by their namespace.
+
+Each subcommand is loaded lazily (see `_lazygroup`) so `dotbot run --help`
+lists everything without importing `dotbot.controller_app` (FastAPI +
+StaticFiles) or the teleop drivers' pygame/pynput.
+"""
+
+import click
+
+from dotbot.cli._lazygroup import LazyGroup
+
+# (cli-name, dotted module path exposing `cmd`, short help under `run --help`)
+_RUN_SUBCOMMANDS = (
+    (
+        "controller",
+        "dotbot.cli.controller",
+        "Control plane + REST/WS + dashboard.",
+    ),
+    (
+        "gateway",
+        "dotbot.cli.gateway",
+        "Host-side Mari gateway bridge (UART <-> MQTT).",
+    ),
+    (
+        "sim",
+        "dotbot.cli.sim",
+        "Standalone simulator (≡ run controller --conn simulator).",
+    ),
+    (
+        "lh2-calibration",
+        "dotbot.cli.calibrate",
+        "LH2 calibration: capture, apply, export (serial-side / single device).",
+    ),
+    (
+        "demo",
+        "dotbot.cli.demo",
+        "Built-in research demos (qrkey phone bridge, ...).",
+    ),
+    ("keyboard", "dotbot.cli.keyboard", "Drive a DotBot from the keyboard (live)."),
+    ("joystick", "dotbot.cli.joystick", "Drive a DotBot from a joystick (live)."),
+)
+
+
+@click.group(
+    cls=LazyGroup,
+    name="run",
+    subcommands=_RUN_SUBCOMMANDS,
+    help=(
+        "Launch host-side processes: the controller (+ REST/WS + UI), the "
+        "gateway bridge, a simulator, LH2 calibration, demos, and teleop "
+        "drivers. These run on your computer; `fw` / `device` / `swarm` are "
+        "the things you manage."
+    ),
+)
+def cmd():
+    pass

--- a/dotbot/cli/sim.py
+++ b/dotbot/cli/sim.py
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""`dotbot sim` — standalone simulator (no hardware).
+"""`dotbot run sim` — standalone simulator (no hardware).
 
-Equivalent to `dotbot controller --conn simulator`. The name advertises
-the no-hardware case so students can discover the offline path from
-`dotbot --help` without reading connection docs.
+Equivalent to `dotbot run controller --conn simulator`. The name
+advertises the no-hardware case so students can discover the offline path
+from `dotbot run --help` without reading connection docs.
 
 Implementation: prepend `--conn simulator` to argv and delegate to the
-controller's Click command. `dotbot sim --sailbot` forwards through to
+controller's Click command. `dotbot run sim --sailbot` forwards through to
 the controller's robot-type selector. A future refactor may turn this
 into a first-class entry (and possibly a separate sim process).
 """
@@ -31,9 +31,9 @@ from dotbot.controller_app import main as _controller_main
 def cmd(ctx):
     """Run a standalone simulator (no hardware required).
 
-    `dotbot sim` runs a dotbot simulator; `dotbot sim --sailbot` runs a
-    sailbot one. Other controller flags are forwarded as-is. Try
-    `dotbot sim --help` for the full option list.
+    `dotbot run sim` runs a dotbot simulator; `dotbot run sim --sailbot`
+    runs a sailbot one. Other controller flags are forwarded as-is. Try
+    `dotbot run sim --help` for the full option list.
     """
     args = ["--conn", "simulator", *ctx.args]
     _controller_main.main(args=args, standalone_mode=True)

--- a/dotbot/dotbot_simulator.py
+++ b/dotbot/dotbot_simulator.py
@@ -755,7 +755,7 @@ def resolve_init_state_path(path: str) -> str:
     ``simulator_init_state.toml`` in the working directory — is used as
     given. When the default is requested and no such file is present,
     fall back to the world shipped inside the package, so the no-hardware
-    path (``dotbot sim`` / ``--conn simulator``) works from any directory
+    path (``dotbot run sim`` / ``--conn simulator``) works from any directory
     and from a pip-installed wheel. An explicit path that does not exist
     is returned unchanged so the caller gets a clear FileNotFoundError.
     """

--- a/dotbot/firmware/boards.py
+++ b/dotbot/firmware/boards.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Board → chip spec: the nrfjprog `-f` family and `--coprocessor` each board needs.
+
+Single source of truth for the flashable board targets and the nrfjprog flags
+they require. `device flash` resolves the board passed via `-b/--board` to a
+`BoardSpec` so it programs the right chip family and core, instead of assuming
+nRF5340.
+
+Family/core values come from the DotBot-firmware `.emProject` device defines
+(`arm_target_device_name`), verified 2026-05-31 — not from guesswork. nRF52 is
+single-core (no `--coprocessor`); the nRF5340 is dual-core (app + net).
+
+Scope: the DotBot ecosystem is exclusively Nordic nRF (nRF52 / nRF5340) for
+now, so this whole flash path assumes nrfjprog. Supporting a non-Nordic SoC
+would mean a flasher-backend abstraction (this table would name the backend),
+not just a new row. That may change if there's enough reason to — on no
+particular timeline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BoardSpec:
+    """How nrfjprog must be invoked for a board.
+
+    - ``family``: nrfjprog ``-f`` value — ``"NRF52"`` or ``"NRF53"``.
+    - ``coprocessor``: nrfjprog ``--coprocessor`` value — ``"CP_APPLICATION"`` /
+      ``"CP_NETWORK"`` on the (dual-core) nRF5340, or ``None`` on the
+      single-core nRF52 (where ``--coprocessor`` does not apply).
+    """
+
+    family: str
+    coprocessor: str | None
+
+
+# Keyed by the build/flash target name. Comment = the chip per its .emProject.
+BOARDS: dict[str, BoardSpec] = {
+    "dotbot-v1": BoardSpec("NRF52", None),  # nRF52833
+    "dotbot-v2": BoardSpec("NRF53", "CP_APPLICATION"),  # nRF5340 (app core)
+    "dotbot-v3": BoardSpec("NRF53", "CP_APPLICATION"),  # nRF5340 (app core)
+    "nrf52833dk": BoardSpec("NRF52", None),
+    "nrf52840dk": BoardSpec("NRF52", None),
+    "nrf5340dk-app": BoardSpec("NRF53", "CP_APPLICATION"),
+    "nrf5340dk-net": BoardSpec("NRF53", "CP_NETWORK"),
+    "sailbot-v1": BoardSpec("NRF52", None),  # nRF52833
+    "freebot-v1.0": BoardSpec("NRF52", None),  # nRF52840
+    "lh2-mini-mote": BoardSpec("NRF52", None),  # nRF52833
+    "xgo-v1": BoardSpec("NRF52", None),  # nRF52833
+    "xgo-v2": BoardSpec("NRF52", None),  # nRF52833
+}
+
+# Fallback for a board not in the table: the historical nRF5340 app-core
+# behavior, so an unlisted target keeps flashing as it did before.
+DEFAULT_SPEC = BoardSpec("NRF53", "CP_APPLICATION")
+
+
+def spec_for(board: str) -> BoardSpec:
+    """Return the `BoardSpec` for a target name (DEFAULT_SPEC if unlisted)."""
+    return BOARDS.get(board, DEFAULT_SPEC)
+
+
+# Which nrfjprog families are multi-core — i.e. expose `--coprocessor` and have
+# more than one core to reset. The nRF5340 is app + net; the nRF52 is
+# single-core. A future multi-core family (e.g. nRF54H) is added here, in one
+# place, instead of scattering `family == "NRF53"` checks through the engine.
+MULTICORE_FAMILIES = frozenset({"NRF53"})
+
+
+def is_multicore_family(family: str) -> bool:
+    """True if `family` has multiple cores (so nrfjprog needs `--coprocessor`)."""
+    return family in MULTICORE_FAMILIES

--- a/dotbot/firmware/flash.py
+++ b/dotbot/firmware/flash.py
@@ -613,17 +613,22 @@ def flash_role(
     )
 
 
-def flash_app_image(image: Path, *, sn_starting_digits: str | None = None) -> None:
-    """Flash a single application image to a provisioned device's app core.
+def flash_app_image(
+    image: Path, *, board: str = "dotbot-v3", sn_starting_digits: str | None = None
+) -> None:
+    """Flash a single firmware image to one cabled device (a whole-chip program).
 
-    Backend for `dotbot device flash <app|file>`. Accepts a `.hex`
-    (flashed as-is) or a `.bin` (converted at APP_FLASH_BASE_ADDR first).
-    The device must already carry the sandbox host (run
-    `dotbot device flash-sandbox-host` first); this writes only the NS
-    application slot via a sector-erase one-core program.
+    Backend for `dotbot device flash <app|file>`. Accepts a `.hex` (flashed
+    as-is) or a `.bin` (converted at APP_FLASH_BASE_ADDR first). `board`
+    selects the nrfjprog family + core via `boards.spec_for`: an nRF52 board
+    flashes its single core; on the nRF5340 a `*-net` board programs the
+    network core, otherwise the application core. No sandbox host required.
     """
+    from .boards import spec_for
+
     if not image.exists():
         raise click.ClickException(f"Firmware image not found: {image}")
+    spec = spec_for(board)
     if sn_starting_digits:
         snr = pick_matching_jlink_snr(sn_starting_digits)
     else:
@@ -633,13 +638,16 @@ def flash_app_image(image: Path, *, sn_starting_digits: str | None = None) -> No
             "Unable to auto-select J-Link; provide --snr explicitly."
         )
     click.echo(f"[INFO] using J-Link with serial number: {snr}")
-    app_hex = (
+    image_hex = (
         convert_bin_to_hex(image, APP_FLASH_BASE_ADDR)
         if image.suffix == ".bin"
         else image
     )
-    click.echo(f"[INFO] flashing app image: {app_hex}")
-    flash_nrf_one_core(app_hex=app_hex, nrfjprog_opt=None, snr_opt=snr)
+    click.echo(f"[INFO] flashing {board} ({spec.family}) image: {image_hex}")
+    if spec.coprocessor == "CP_NETWORK":
+        flash_nrf_one_core(net_hex=image_hex, family=spec.family, snr_opt=snr)
+    else:
+        flash_nrf_one_core(app_hex=image_hex, family=spec.family, snr_opt=snr)
     click.secho("\n[INFO] ==== Flash Complete ====\n", fg="green")
 
 

--- a/dotbot/firmware/nrf.py
+++ b/dotbot/firmware/nrf.py
@@ -6,6 +6,8 @@ import tempfile
 import time
 from pathlib import Path
 
+from .boards import is_multicore_family
+
 # Timings
 POLL_INTERVAL = 1.0
 TIMEOUT_JLINK_SEC = 120
@@ -255,6 +257,7 @@ def nrfjprog_program(
     nrfjprog,
     hex_path,
     network=False,
+    family="NRF53",
     verify=True,
     reset=True,
     chiperase=True,
@@ -263,13 +266,13 @@ def nrfjprog_program(
 ):
     if chiperase and sectorerase:
         raise ValueError("Use only one of chiperase or sectorerase.")
-    args = [nrfjprog, "-f", "NRF53"]
+    args = [nrfjprog, "-f", family]
     if snr:
         args += ["-s", str(snr)]
-    if network:
-        args += ["--coprocessor", "CP_NETWORK"]
-    else:
-        args += ["--coprocessor", "CP_APPLICATION"]
+    # --coprocessor only applies to multi-core families (the nRF5340); a
+    # single-core family (nRF52) has no coprocessor and rejects the flag.
+    if is_multicore_family(family):
+        args += ["--coprocessor", "CP_NETWORK" if network else "CP_APPLICATION"]
     args += ["--program", str(hex_path)]
     if verify:
         args += ["--verify"]
@@ -395,10 +398,15 @@ def flash_nrf_both_cores(
 def flash_nrf_one_core(
     app_hex: Path | None = None,
     net_hex: Path | None = None,
+    family: str = "NRF53",
     nrfjprog_opt: str | None = None,
     snr_opt: str | None = None,
 ):
-    """Flash only one core; no recover and no chiperase."""
+    """Flash only one core; no recover and no chiperase.
+
+    `family` is the nrfjprog `-f` value ("NRF53" / "NRF52"). On nRF52 there is
+    no network core, so `net_hex` and the per-core reset are nRF5340-only.
+    """
     if app_hex is None and net_hex is None:
         raise FileNotFoundError("Provide app_hex or net_hex.")
     if app_hex is not None and net_hex is not None:
@@ -422,11 +430,12 @@ def flash_nrf_one_core(
     print(f"[INFO] Using J-Link with serial number: {snr}")
 
     if app_hex is not None:
-        print("== Flashing nRF5340 application core with nrfjprog ==")
+        print(f"== Flashing {family} application core with nrfjprog ==")
         nrfjprog_program(
             nrfjprog,
             app_hex,
             network=False,
+            family=family,
             verify=True,
             reset=True,
             chiperase=False,
@@ -435,11 +444,12 @@ def flash_nrf_one_core(
         )
         print("[OK] Application core programmed.")
     else:
-        print("== Flashing nRF5340 network core with nrfjprog ==")
+        print(f"== Flashing {family} network core with nrfjprog ==")
         nrfjprog_program(
             nrfjprog,
             net_hex,
             network=True,
+            family=family,
             verify=True,
             reset=True,
             chiperase=False,
@@ -447,17 +457,24 @@ def flash_nrf_one_core(
             snr=snr,
         )
         print("[OK] Network core programmed.")
-    # reset both cores
     time.sleep(0.5)
-    nrfjprog_reset_core(nrfjprog, snr=snr, core="CP_NETWORK")
-    nrfjprog_reset_core(nrfjprog, snr=snr, core="CP_APPLICATION")
+    if is_multicore_family(family):
+        # reset every core
+        nrfjprog_reset_core(nrfjprog, snr=snr, core="CP_NETWORK", family=family)
+        nrfjprog_reset_core(nrfjprog, snr=snr, core="CP_APPLICATION", family=family)
+    else:
+        # single-core family: one reset, no --coprocessor
+        nrfjprog_reset_core(nrfjprog, snr=snr, core=None, family=family)
 
 
-def nrfjprog_reset_core(nrfjprog, snr=None, core="CP_APPLICATION"):
-    args = [nrfjprog, "-f", "NRF53"]
+def nrfjprog_reset_core(nrfjprog, snr=None, core="CP_APPLICATION", family="NRF53"):
+    args = [nrfjprog, "-f", family]
     if snr:
         args += ["-s", str(snr)]
-    args += ["--reset", "--coprocessor", core]
+    args += ["--reset"]
+    # --coprocessor is multi-core-only; a single-core family resets directly.
+    if is_multicore_family(family) and core:
+        args += ["--coprocessor", core]
     rc, out = run(args, timeout=120)
     if rc != 0 or "ERROR" in out.upper() or "failed" in out.lower():
         raise RuntimeError("nrfjprog reset failed; see log above.")

--- a/dotbot/tests/test_adapter.py
+++ b/dotbot/tests/test_adapter.py
@@ -203,7 +203,7 @@ def test_simulator_adapter_close_before_start_is_noop():
 
 def test_resolve_init_state_path_falls_back_to_packaged(tmp_path, monkeypatch):
     """The default init-state resolves to the packaged world when no file
-    exists in the cwd, so `dotbot sim` works from any directory."""
+    exists in the cwd, so `dotbot run sim` works from any directory."""
     from dotbot import SIMULATOR_INIT_STATE_DEFAULT
     from dotbot.dotbot_simulator import resolve_init_state_path
 

--- a/dotbot/tests/test_cli_dispatcher.py
+++ b/dotbot/tests/test_cli_dispatcher.py
@@ -3,10 +3,10 @@
 
 """Tests for the `dotbot` CLI dispatcher.
 
-Goal: lock the discovery surface (subcommand list + --help) so a
-future refactor doesn't silently drop a command. We're NOT testing
-the underlying subcommand behavior here — that lives in each
-subcommand's own test module (test_controller_app.py etc.).
+Goal: lock the discovery surface (the four top-level groups + the `run`
+process group + --help) so a future refactor doesn't silently drop a
+command. We're NOT testing the underlying subcommand behavior here — that
+lives in each subcommand's own test module (test_controller_app.py etc.).
 """
 
 import os
@@ -18,6 +18,7 @@ from click.testing import CliRunner
 
 from dotbot.cli import _lazy
 from dotbot.cli.main import _SUBCOMMANDS, cli
+from dotbot.cli.run import _RUN_SUBCOMMANDS
 
 # Importing dotbot.controller (transitively, dotbot.server) blows up at
 # module-import time if the React UI hasn't been built — FastAPI's
@@ -31,42 +32,42 @@ _FRONTEND_BUILD = os.path.join(
     "build",
 )
 _FRONTEND_PRESENT = os.path.isdir(_FRONTEND_BUILD)
-_needs_frontend = pytest.mark.skipif(
-    not _FRONTEND_PRESENT,
-    reason=(
-        "frontend bundle missing — run `cd dotbot/frontend && npm run build`. "
-        "The CLI scaffold itself does not depend on the bundle; this skip "
-        "exists because dotbot.server.api.mount(StaticFiles) runs at import."
-    ),
-)
 
 
+# The top level is exactly four object-namespaces.
 EXPECTED_SUBCOMMANDS = {
-    "controller",
-    "sim",
-    "gateway",
+    "fw",
     "device",
     "swarm",
-    "calibrate-lh2",
+    "run",
+}
+
+# `run` groups the host-side processes (the former flat top-level verbs).
+EXPECTED_RUN_SUBCOMMANDS = {
+    "controller",
+    "gateway",
+    "sim",
+    "lh2-calibration",
     "demo",
-    "fw",
-    "make",
     "keyboard",
     "joystick",
 }
 
-# Subcommands whose --help backends live in OTHER packages with their
-# own protocol registries (swarmit). When pytest pre-loads
-# dotbot.protocol via test_controller etc., importing swarmit in the
-# same process triggers a duplicate payload-type registration
-# (ValueError 0x81 already registered). This is the known cross-package
-# protocol duplication captured in the consolidation roadmap §1; it
-# never happens in real `dotbot <sub>` invocations (each shell run is
-# a fresh process). We verify these in a subprocess.
-#
-# `calibrate` used to be in this set; after Phase 2's fold it's in-tree
-# and uses dotbot's own (vendored) modules, no collision possible.
+# Top-level groups whose --help backend lives in OTHER packages with their
+# own protocol registries (swarmit). When pytest pre-loads dotbot.protocol
+# via test_controller etc., importing swarmit in the same process triggers
+# a duplicate payload-type registration (ValueError 0x81 already
+# registered). This is the known cross-package protocol duplication
+# captured in the consolidation roadmap §1; it never happens in real
+# `dotbot <sub>` invocations (each shell run is a fresh process). We verify
+# these in a subprocess.
 _CROSS_PACKAGE_SUBS = {"swarm"}
+
+# `run` subcommands whose lazy import is hostile to an in-process headless
+# test: keyboard/joystick import pygame/pynput at module load;
+# controller/sim trigger dotbot.server's StaticFiles import-time mount.
+_TELEOP_SUBS = {"keyboard", "joystick"}
+_FRONTEND_DEPENDENT = {"controller", "sim"}
 
 
 @pytest.fixture
@@ -74,17 +75,50 @@ def runner():
     return CliRunner()
 
 
-def test_root_help_lists_every_subcommand(runner):
+def test_root_help_lists_the_four_namespaces(runner):
     result = runner.invoke(cli, ["--help"])
     assert result.exit_code == 0, result.output
+    # Check the rendered "Commands:" section specifically — the root help
+    # prose also names the four groups, so a bare full-output substring
+    # check would pass even if a command were dropped from the list.
+    commands = result.output.split("Commands:", 1)[1]
     for name in EXPECTED_SUBCOMMANDS:
-        assert name in result.output, f"subcommand `{name}` missing from --help"
+        assert name in commands, f"namespace `{name}` missing from rendered list"
 
 
 def test_subcommand_table_matches_expected_set():
-    """The static `_SUBCOMMANDS` tuple is the wiring contract."""
+    """The static top-level `_SUBCOMMANDS` tuple is the wiring contract."""
     declared = {name for name, _, _ in _SUBCOMMANDS}
     assert declared == EXPECTED_SUBCOMMANDS
+
+
+def test_run_help_lists_every_process(runner):
+    result = runner.invoke(cli, ["run", "--help"])
+    assert result.exit_code == 0, result.output
+    # Same as the root: assert against the rendered command list, not the
+    # prose (which contains "controller"/"gateway"/"sim"/"demo" as words).
+    commands = result.output.split("Commands:", 1)[1]
+    for name in EXPECTED_RUN_SUBCOMMANDS:
+        assert name in commands, f"`run {name}` missing from rendered list"
+
+
+def test_run_subcommand_table_matches_expected_set():
+    """The static `_RUN_SUBCOMMANDS` tuple is the `run`-group contract."""
+    declared = {name for name, _, _ in _RUN_SUBCOMMANDS}
+    assert declared == EXPECTED_RUN_SUBCOMMANDS
+
+
+def test_no_flat_process_verbs_at_top_level(runner):
+    """The host-process verbs must NOT be reachable at the top level —
+    they moved under `run`. This is the regression guard for the reorg."""
+    for name in EXPECTED_RUN_SUBCOMMANDS:
+        result = runner.invoke(cli, [name, "--help"])
+        assert result.exit_code != 0, f"`dotbot {name}` should no longer exist"
+        # Assert it failed because the command is GONE, not because a
+        # re-added verb's backend errored at import (which also exits != 0).
+        assert (
+            "No such command" in result.output
+        ), f"`dotbot {name}` failed for the wrong reason:\n{result.output}"
 
 
 def test_version_flag(runner):
@@ -93,29 +127,39 @@ def test_version_flag(runner):
     assert "dotbot" in result.output
 
 
-_FRONTEND_DEPENDENT = {"controller", "sim"}
+@pytest.mark.parametrize(
+    "subcommand",
+    sorted(EXPECTED_SUBCOMMANDS - _CROSS_PACKAGE_SUBS),
+)
+def test_top_level_group_help_works(runner, subcommand):
+    """Every in-process top-level group's --help runs cleanly.
+
+    swarm is excluded (its swarmit backend collides with PyDotBot's
+    protocol registry inside a single pytest process — covered separately
+    by the subprocess test). fw/device/run import no heavy backend at
+    --help time.
+    """
+    result = runner.invoke(cli, [subcommand, "--help"])
+    assert result.exit_code == 0, result.output
 
 
 @pytest.mark.parametrize(
     "subcommand",
-    sorted(EXPECTED_SUBCOMMANDS - {"keyboard", "joystick"} - _CROSS_PACKAGE_SUBS),
+    sorted(EXPECTED_RUN_SUBCOMMANDS - _TELEOP_SUBS),
 )
-def test_subcommand_help_works(runner, subcommand):
-    """Every in-process subcommand's --help runs cleanly.
+def test_run_subcommand_help_works(runner, subcommand):
+    """Every in-process `run` subcommand's --help runs cleanly.
 
     keyboard/joystick are excluded because they import pygame/pynput at
-    module load time (headless-CI hostile). swarm is excluded because
-    its swarmit backend collides with PyDotBot's protocol registry
-    inside a single pytest process — covered separately by
-    test_cross_package_subcommand_help_works in a subprocess.
-    controller/sim trigger dotbot.server's StaticFiles import-time mount;
-    skipped if the frontend bundle hasn't been built.
+    module load time (headless-CI hostile). controller/sim trigger
+    dotbot.server's StaticFiles import-time mount; skipped if the frontend
+    bundle hasn't been built.
     """
     if subcommand in _FRONTEND_DEPENDENT and not _FRONTEND_PRESENT:
         pytest.skip(
             "frontend bundle missing; run `cd dotbot/frontend && npm run build`"
         )
-    result = runner.invoke(cli, [subcommand, "--help"])
+    result = runner.invoke(cli, ["run", subcommand, "--help"])
     assert result.exit_code == 0, result.output
 
 
@@ -123,9 +167,9 @@ def test_subcommand_help_works(runner, subcommand):
 def test_cross_package_subcommand_help_works(subcommand):
     """`dotbot swarm --help` in a clean process.
 
-    A subprocess avoids the swarmit/lh2-calibration vs PyDotBot
-    protocol-registry collision that only manifests inside pytest's
-    shared-process test session. See _CROSS_PACKAGE_SUBS comment above.
+    A subprocess avoids the swarmit vs PyDotBot protocol-registry
+    collision that only manifests inside pytest's shared-process test
+    session. See _CROSS_PACKAGE_SUBS comment above.
     """
     result = subprocess.run(
         [sys.executable, "-m", "dotbot.cli", subcommand, "--help"],
@@ -139,6 +183,39 @@ def test_cross_package_subcommand_help_works(subcommand):
     assert "Usage" in combined
 
 
+def test_run_help_does_not_import_controller_app():
+    """`dotbot run --help` must NOT eagerly import the heavy controller
+    backend — that's the whole point of the lazy `run` group.
+
+    Run in a fresh subprocess so sys.modules is clean (other test modules
+    in the shared pytest process may already have imported it).
+    """
+    code = (
+        "import sys;"
+        "from click.testing import CliRunner;"
+        "from dotbot.cli.main import cli;"
+        "r = CliRunner().invoke(cli, ['run', '--help']);"
+        "assert r.exit_code == 0, r.output;"
+        "heavy = [m for m in ('dotbot.controller_app','dotbot.server',"
+        "'pygame','pynput','dotbot.calibration') if m in sys.modules];"
+        "assert not heavy, f'run --help eagerly imported: {heavy}';"
+        "print('OK')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+def test_fw_make_is_mounted_under_fw(runner):
+    """The make escape hatch lives at `dotbot fw make`, not top-level."""
+    result = runner.invoke(cli, ["fw", "make", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "SEGGER_DIR" in result.output
+    # And it is gone from the top level.
+    assert runner.invoke(cli, ["make", "--help"]).exit_code != 0
+
+
 def test_fw_mock_exits_nonzero(runner):
     """fw stubs must surface that they're not implemented (exit 2)."""
     result = runner.invoke(cli, ["fw", "new", "myapp"])
@@ -147,15 +224,15 @@ def test_fw_mock_exits_nonzero(runner):
 
 
 def test_demo_list(runner):
-    """`dotbot demo --list` enumerates demos including `qr`."""
-    result = runner.invoke(cli, ["demo", "--list"])
+    """`dotbot run demo --list` enumerates demos including `qr`."""
+    result = runner.invoke(cli, ["run", "demo", "--list"])
     assert result.exit_code == 0
     assert "qr" in result.output
 
 
 def test_demo_default_lists(runner):
-    """`dotbot demo` with no subcommand also lists (discoverability)."""
-    result = runner.invoke(cli, ["demo"])
+    """`dotbot run demo` with no subcommand also lists (discoverability)."""
+    result = runner.invoke(cli, ["run", "demo"])
     assert result.exit_code == 0
     assert "qr" in result.output
 
@@ -214,27 +291,8 @@ def test_python_m_dotbot_cli_version_subprocess():
     assert "dotbot" in result.stdout
 
 
-@_needs_frontend
-def test_legacy_console_scripts_still_resolve():
-    """Backwards-compat aliases (dotbot-controller, dotbot-keyboard,
-    dotbot-joystick) must still resolve to importable Click commands.
-
-    Checks the entry-point targets via direct import. Skipped without
-    the frontend bundle because dotbot.controller_app pulls in
-    dotbot.server which mounts StaticFiles at import.
-    """
-    import click
-
-    from dotbot.controller_app import main as controller_main
-    from dotbot.joystick import main as joystick_main
-    from dotbot.keyboard import main as keyboard_main
-
-    for cmd in (controller_main, keyboard_main, joystick_main):
-        assert isinstance(cmd, click.Command), f"{cmd!r} is not a Click cmd"
-
-
-def test_calibrate_lh2_missing_extras_prints_hint(runner, monkeypatch):
-    """When [calibrate] extras aren't installed, `dotbot calibrate-lh2`
+def test_lh2_calibration_missing_extras_prints_hint(runner, monkeypatch):
+    """When [calibrate] extras aren't installed, `dotbot run lh2-calibration`
     (default `collect`) exits 1 with a pip-install hint instead of a
     traceback."""
     # Simulate the dotbot.calibration.cli module being unavailable.
@@ -242,36 +300,38 @@ def test_calibrate_lh2_missing_extras_prints_hint(runner, monkeypatch):
     # `from name import ...` raise ImportError per CPython's import
     # protocol — same condition as a real missing extra.
     monkeypatch.setitem(sys.modules, "dotbot.calibration.cli", None)
-    result = runner.invoke(cli, ["calibrate-lh2"])
+    result = runner.invoke(cli, ["run", "lh2-calibration"])
     assert result.exit_code == 1, result.output
     assert "pip install dotbot[calibrate]" in result.output
 
 
-def test_calibrate_lh2_collect_missing_extras_prints_hint(runner, monkeypatch):
-    """`dotbot calibrate-lh2 collect` is the explicit alias for the
+def test_lh2_calibration_collect_missing_extras_prints_hint(runner, monkeypatch):
+    """`dotbot run lh2-calibration collect` is the explicit alias for the
     default; same install-hint fallback when extras are missing."""
     monkeypatch.setitem(sys.modules, "dotbot.calibration.cli", None)
-    result = runner.invoke(cli, ["calibrate-lh2", "collect"])
+    result = runner.invoke(cli, ["run", "lh2-calibration", "collect"])
     assert result.exit_code == 1, result.output
     assert "pip install dotbot[calibrate]" in result.output
 
 
-def test_calibrate_lh2_apply_missing_extras_prints_hint(runner, monkeypatch):
-    """`dotbot calibrate-lh2 apply` falls back to the install hint
+def test_lh2_calibration_apply_missing_extras_prints_hint(runner, monkeypatch):
+    """`dotbot run lh2-calibration apply` falls back to the install hint
     when the calibration runtime deps aren't available."""
     monkeypatch.setitem(sys.modules, "dotbot.calibration.exporter", None)
     monkeypatch.setitem(sys.modules, "dotbot.calibration.lighthouse2", None)
-    result = runner.invoke(cli, ["calibrate-lh2", "apply", "/tmp/lh2.h"])
+    result = runner.invoke(cli, ["run", "lh2-calibration", "apply", "/tmp/lh2.h"])
     assert result.exit_code == 1, result.output
     assert "pip install dotbot[calibrate]" in result.output
 
 
-def test_calibrate_lh2_apply_no_saved_calibration(runner, tmp_path, monkeypatch):
+def test_lh2_calibration_apply_no_saved_calibration(runner, tmp_path, monkeypatch):
     """`apply` exits 1 with a clear message when no saved calibration
     exists at the expected location."""
     # Point LighthouseManager at an empty tmp dir so load_calibration
     # finds nothing.
     monkeypatch.setattr("dotbot.calibration.lighthouse2.CALIBRATION_DIR", tmp_path)
-    result = runner.invoke(cli, ["calibrate-lh2", "apply", str(tmp_path / "out.h")])
+    result = runner.invoke(
+        cli, ["run", "lh2-calibration", "apply", str(tmp_path / "out.h")]
+    )
     assert result.exit_code == 1, result.output
     assert "No saved calibration" in result.output

--- a/dotbot/tests/test_device.py
+++ b/dotbot/tests/test_device.py
@@ -73,10 +73,10 @@ def test_flash_sandbox_host_requires_network_id_and_version(runner):
 
 
 def test_flash_gateway_help_disambiguates_from_bridge(runner):
-    """`device flash-gateway` help points away from the `dotbot gateway` bridge."""
+    """`device flash-gateway` help points away from the `dotbot run gateway` bridge."""
     result = runner.invoke(device_cmd, ["flash-gateway", "--help"])
     assert result.exit_code == 0
-    assert "dotbot gateway" in result.output  # the "use the bridge instead" note
+    assert "dotbot run gateway" in result.output  # the "use the bridge instead" note
 
 
 def test_flash_sandbox_host_calls_engine(runner, _no_nrfjprog_gate, monkeypatch):

--- a/dotbot/tests/test_flash_boards.py
+++ b/dotbot/tests/test_flash_boards.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Board → nrfjprog family/core resolution and `device flash` routing.
+
+Locks the fix for the nRF53-only flash bug: `device flash` must program the
+right chip family (`-f NRF52` vs `NRF53`) and core (`--coprocessor`) for the
+board, instead of always assuming nRF5340. Hardware-free — `run` (the nrfjprog
+subprocess) and the J-Link picker are monkeypatched.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from dotbot.cli._fw_helpers import BARE_TARGETS
+from dotbot.firmware import boards, flash, nrf
+
+# ── board spec table ────────────────────────────────────────────────────
+
+
+def test_spec_for_known_boards():
+    assert boards.spec_for("nrf52840dk") == boards.BoardSpec("NRF52", None)
+    assert boards.spec_for("nrf52833dk") == boards.BoardSpec("NRF52", None)
+    assert boards.spec_for("dotbot-v3") == boards.BoardSpec("NRF53", "CP_APPLICATION")
+    assert boards.spec_for("nrf5340dk-app") == boards.BoardSpec(
+        "NRF53", "CP_APPLICATION"
+    )
+    assert boards.spec_for("nrf5340dk-net") == boards.BoardSpec("NRF53", "CP_NETWORK")
+
+
+def test_spec_for_unknown_board_falls_back_to_default():
+    assert boards.spec_for("totally-made-up") == boards.DEFAULT_SPEC
+    assert boards.DEFAULT_SPEC.family == "NRF53"
+
+
+def test_bare_targets_is_the_board_table():
+    """BARE_TARGETS is derived from BOARDS — one source of truth."""
+    assert set(BARE_TARGETS) == set(boards.BOARDS)
+
+
+def test_is_multicore_family():
+    assert boards.is_multicore_family("NRF53") is True
+    assert boards.is_multicore_family("NRF52") is False
+
+
+def test_board_family_and_coprocessor_are_consistent():
+    """A board carries a coprocessor iff its family is multi-core — so a bad
+    row (NRF52 with a coprocessor, or NRF53 without one) fails here."""
+    for name, spec in boards.BOARDS.items():
+        if boards.is_multicore_family(spec.family):
+            assert spec.coprocessor is not None, name
+        else:
+            assert spec.coprocessor is None, name
+
+
+# ── nrfjprog arg construction (the actual bug) ──────────────────────────
+
+
+@pytest.fixture
+def capture_nrfjprog(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, timeout=None, cwd=None):
+        calls.append(cmd)
+        return 0, "OK"
+
+    monkeypatch.setattr("dotbot.firmware.nrf.run", fake_run)
+    return calls
+
+
+def test_nrfjprog_program_nrf52_uses_nrf52_and_no_coprocessor(capture_nrfjprog):
+    nrf.nrfjprog_program("nrfjprog", Path("x.hex"), family="NRF52", chiperase=True)
+    args = capture_nrfjprog[0]
+    assert args[args.index("-f") + 1] == "NRF52"
+    assert "--coprocessor" not in args  # nRF52 is single-core
+
+
+def test_nrfjprog_program_nrf53_app_uses_cp_application(capture_nrfjprog):
+    nrf.nrfjprog_program("nrfjprog", Path("x.hex"), network=False, family="NRF53")
+    args = capture_nrfjprog[0]
+    assert args[args.index("-f") + 1] == "NRF53"
+    assert "CP_APPLICATION" in args
+
+
+def test_nrfjprog_program_nrf53_net_uses_cp_network(capture_nrfjprog):
+    nrf.nrfjprog_program("nrfjprog", Path("x.hex"), network=True, family="NRF53")
+    assert "CP_NETWORK" in capture_nrfjprog[0]
+
+
+# ── device flash routing: board → family/core ──────────────────────────
+
+
+@pytest.fixture
+def capture_one_core(monkeypatch):
+    calls = []
+
+    def fake_one_core(
+        app_hex=None, net_hex=None, family="NRF53", nrfjprog_opt=None, snr_opt=None
+    ):
+        calls.append({"app_hex": app_hex, "net_hex": net_hex, "family": family})
+
+    monkeypatch.setattr("dotbot.firmware.flash.flash_nrf_one_core", fake_one_core)
+    monkeypatch.setattr(
+        "dotbot.firmware.flash.pick_last_jlink_snr", lambda *a, **k: "777"
+    )
+    return calls
+
+
+def test_flash_app_image_nrf52_board_flashes_app_core_nrf52(tmp_path, capture_one_core):
+    img = tmp_path / "dotbot_gateway-nrf52840dk.hex"
+    img.write_text(":00000001FF\n")
+    flash.flash_app_image(img, board="nrf52840dk")
+    call = capture_one_core[0]
+    assert call["family"] == "NRF52"
+    assert call["app_hex"] == img and call["net_hex"] is None
+
+
+def test_flash_app_image_net_board_flashes_net_core(tmp_path, capture_one_core):
+    img = tmp_path / "nrf5340_net-nrf5340dk-net.hex"
+    img.write_text(":00000001FF\n")
+    flash.flash_app_image(img, board="nrf5340dk-net")
+    call = capture_one_core[0]
+    assert call["family"] == "NRF53"
+    assert call["net_hex"] == img and call["app_hex"] is None
+
+
+def test_flash_app_image_default_board_is_nrf53_app_core(tmp_path, capture_one_core):
+    img = tmp_path / "dotbot-dotbot-v3.hex"
+    img.write_text(":00000001FF\n")
+    flash.flash_app_image(img)  # default board dotbot-v3
+    call = capture_one_core[0]
+    assert call["family"] == "NRF53" and call["app_hex"] == img

--- a/dotbot/tests/test_fw.py
+++ b/dotbot/tests/test_fw.py
@@ -457,7 +457,7 @@ def test_sandbox_build_prints_preamble(runner, fake_repo, fake_segger, capture_m
     assert "✓ Built" in result.output
 
 
-# ── `dotbot make` escape hatch ──────────────────────────────────────────
+# ── `dotbot fw make` escape hatch ───────────────────────────────────────
 
 
 from dotbot.cli.make import cmd as make_cmd  # noqa: E402
@@ -491,7 +491,7 @@ def test_dotbot_make_help_lists_examples(runner):
 def test_dotbot_make_forwards_args_verbatim(
     runner, fake_repo, fake_segger, capture_make_passthrough
 ):
-    """`dotbot make foo bar BAZ=qux` invokes `make foo bar BAZ=qux`."""
+    """`dotbot fw make foo bar BAZ=qux` invokes `make foo bar BAZ=qux`."""
     result = runner.invoke(
         make_cmd, ["help", "BUILD_TARGET=dotbot-v3", "PACKAGES_DIR_OPT=-p /opt"]
     )
@@ -536,7 +536,7 @@ def test_dotbot_make_propagates_make_exit_code(
 def test_fw_help_points_at_dotbot_make(runner):
     result = runner.invoke(fw_cmd, ["--help"])
     assert result.exit_code == 0
-    assert "dotbot make" in result.output
+    assert "dotbot fw make" in result.output
 
 
 # ── Helper-level tests ──────────────────────────────────────────────────

--- a/dotbot/tests/test_gateway.py
+++ b/dotbot/tests/test_gateway.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026-present Inria
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Tests for `dotbot gateway` — the CLI surface, not the live bridge.
+"""Tests for `dotbot run gateway` — the CLI surface, not the live bridge.
 
 The bridge itself (`_run_gateway`) needs a real serial gateway, so it's
 mocked here; we check flag parsing and that the command forwards

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,21 +70,10 @@ classifiers = [
 "Bug Tracker" = "https://github.com/DotBots/PyDotBot/issues"
 
 [project.scripts]
-# Unified dispatcher.
+# The unified dispatcher is the only console script. Every workflow is a
+# `dotbot <group> <verb>` subcommand — there are no per-command `dotbot-*`
+# binaries.
 dotbot = "dotbot.cli.main:cli"
-
-# Legacy entry points kept as backwards-compat aliases for one release.
-# They will be removed once external scripts have migrated to
-# `dotbot <subcommand>`.
-dotbot-controller = "dotbot.controller_app:main"
-dotbot-keyboard = "dotbot.keyboard:main"
-dotbot-joystick = "dotbot.joystick:main"
-# No backwards-compat aliases for the folded-in tooling
-# (provision, calibration): those console scripts never existed
-# in dotbot-python — the names belonged to the standalone PyPI
-# packages, which keep their own scripts during their own
-# deprecation cycle. Users coming from those packages use
-# `dotbot device flash-…` and `dotbot calibrate-lh2 …`.
 
 [project.optional-dependencies]
 # Optional subcommand backends. Keep the core install lean; opt in to

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ allowlist_externals=
     /usr/bin/bash
 commands=
     bash -exc "dotbot --help"
-    bash -exc "dotbot-controller --help"
+    bash -exc "dotbot run controller --help"
 
 [testenv:web]
 allowlist_externals=


### PR DESCRIPTION
## What

Reorganizes the `dotbot` CLI top level into four object-namespaces — each one *kind of thing*:

- `fw` — firmware artifacts (build / fetch / list / make)
- `device` — one connected device over the cable (flash an app/role, read info)
- `swarm` — the fleet over the air (status, start/stop, OTA flash, monitor)
- `run` — host-side processes you launch (controller, gateway, sim, lh2-calibration, demo, keyboard, joystick)

Three groups are nouns you *manage*; `run` is the verb. `dotbot --help` now teaches the system in four lines instead of listing ten flat entries of two different kinds.

## Why

The earlier `fw` / `device` / `swarm` split fixed only the resource side; the host-process commands were still flat top-level entries sitting next to the resource groups — two ontologies at one level. This finishes the taxonomy so every top-level entry is one kind of thing.

## Breaking changes (no aliases — clean break)

- Flat process verbs move under `run`: `dotbot controller` → `dotbot run controller` (likewise `gateway` / `sim` / `demo` / `keyboard` / `joystick`), and `dotbot calibrate-lh2` → `dotbot run lh2-calibration`.
- `dotbot make` → `dotbot fw make`.
- The legacy `dotbot-controller` / `dotbot-keyboard` / `dotbot-joystick` console scripts are removed; `dotbot` is the only console script.

## Notable for review

- Lazy loading is preserved one level deeper: `dotbot run --help` lists all seven processes without importing the heavy controller/teleop backends — a dedicated subprocess test locks this.
- The dispatcher's deferred-import group is extracted into a reusable `LazyGroup`, shared by the root and the `run` group.
- The moved commands keep their flags/behavior verbatim; only their path and self-referential help text change.

## Validation

- Full test suite green; the dispatcher contract tests were rewritten to lock the four-group tree, the `run` subcommands (incl. the `lh2-calibration` rename), the `fw make` mount, and the lazy-load guarantee.
- Full pre-commit chain clean.
- The swarm flow was exercised on hardware.