### PR TITLE
dotbot/config: add the unified config resolver (phase 1)

### DIFF
--- a/dotbot/config.py
+++ b/dotbot/config.py
@@ -1,0 +1,345 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unified `dotbot` configuration: one file, one precedence chain.
+
+This is the resolver core for the single `dotbot` config file. It is
+intentionally pure - no Click, no network, no global state - so the whole
+precedence/discovery story is
+exhaustively unit-testable without hardware. The CLI layer (a later phase)
+feeds it the actual flags and `os.environ`.
+
+The file mirrors the four-namespace CLI: top-level shared keys plus `[fw]` /
+`[device]` / `[swarm]` / `[run]` tables, and `[testbed.<name>]` entries for the
+physical deployments you switch between.
+
+```toml
+default_testbed = "inria"
+conn     = "mqtts://broker.local:8883"   # shared; sections/testbeds override
+swarm_id = "0001"
+
+[testbed.inria]                          # a named deployment - select, don't edit
+conn = "mqtts://broker.inria.fr:8883"
+swarm_id = "0001"
+
+[fw]
+board = "dotbot-v3"
+
+[run.controller]
+http_port = 8000
+```
+
+Precedence for any value, highest wins:
+
+    CLI flag  >  env (DOTBOT_<SECTION>_<KEY>, then shared DOTBOT_<KEY>)
+              >  file (section value > selected testbed > top-level)
+              >  built-in default
+
+The selected testbed (`--testbed` > `DOTBOT_TESTBED` > `default_testbed`)
+resolves first and slots into the file layer; an explicit flag/env still beats
+it. Unknown keys are rejected (`extra='forbid'`) so a typo fails loud.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+from typing import Annotated, Any, Mapping, Optional
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+)
+
+# The four CLI namespaces, used to derive env-var names (DOTBOT_<SECTION>_<KEY>).
+SECTIONS = ("fw", "device", "swarm", "run")
+
+# Where the user-level config lives. Geovane's call (2026-06-01): one dir,
+# shared with the calibration data under ~/.dotbot/ - no XDG split.
+USER_CONFIG_PATH = Path.home() / ".dotbot" / "config.toml"
+# Project-level config, discovered by walking up from the cwd.
+PROJECT_CONFIG_NAME = "dotbot.toml"
+
+
+class ConfigError(Exception):
+    """A config file is malformed, has an unknown key, or names a missing testbed."""
+
+
+def _check_conn(value: str | None) -> str | None:
+    """Validate a connection string with the same parser the `--conn` flag uses.
+
+    One validator for the file path and the flag path, so they can't drift.
+    Imported lazily so merely importing this module doesn't pull in marilib.
+    """
+    if value is None:
+        return value
+    from dotbot.cli._conn import ConnError, parse_connection
+
+    try:
+        parse_connection(value)
+    except ConnError as exc:
+        raise ValueError(str(exc)) from exc
+    return value
+
+
+# A connection string validated against `parse_connection` wherever it appears.
+Conn = Annotated[Optional[str], AfterValidator(_check_conn)]
+
+
+class _Strict(BaseModel):
+    """Base for every config section: reject unknown keys so typos fail loud."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# All fields are Optional and default to None: the model captures only what the
+# file *explicitly* set, so the resolver can tell "unset" from "set to the
+# default" and apply the precedence chain correctly. Built-in defaults live in
+# code (dotbot/__init__.py), not here.
+
+
+class Testbed(_Strict):
+    """One named physical deployment (Inria/100, La Poste/1000, ...).
+
+    Holds only the environment-binding keys plus descriptive metadata. You
+    select a testbed; you never edit the file to switch.
+    """
+
+    conn: Conn = None
+    swarm_id: str | None = None
+    serial_port: str | None = None
+    location: str | None = None  # descriptive, for `dotbot testbed list`
+    bots: int | None = None  # descriptive
+
+
+class FwSection(_Strict):
+    board: str | None = None
+    sandbox: bool | None = None
+    build_config: str | None = None  # Debug | Release
+    segger_dir: str | None = None
+
+
+class DeviceSection(_Strict):
+    board: str | None = None
+    sn_starting_digits: str | None = None
+    build_config: str | None = None
+
+
+class SwarmSection(_Strict):
+    conn: Conn = None
+    swarm_id: str | None = None
+    devices: str | None = None
+
+
+class ControllerSection(_Strict):
+    http_port: int | None = None
+    map_size: str | None = None
+    background_map: str | None = None
+    log_output: str | None = None
+    csv_data_output: str | None = None
+    webbrowser: bool | None = None
+    gw_address: str | None = None
+    simulator_init_state: str | None = None
+
+
+class GatewaySection(_Strict):
+    serial_port: str | None = None
+    mqtt: Conn = None
+
+
+class RunSection(_Strict):
+    conn: Conn = None
+    swarm_id: str | None = None
+    controller: ControllerSection = Field(default_factory=ControllerSection)
+    gateway: GatewaySection = Field(default_factory=GatewaySection)
+
+
+class DotbotConfig(_Strict):
+    """The whole file: top-level shared keys + the four section tables + testbeds."""
+
+    default_testbed: str | None = None
+    artifacts_dir: str | None = None
+    log_level: str | None = None
+    conn: Conn = None
+    swarm_id: str | None = None
+
+    fw: FwSection = Field(default_factory=FwSection)
+    device: DeviceSection = Field(default_factory=DeviceSection)
+    swarm: SwarmSection = Field(default_factory=SwarmSection)
+    run: RunSection = Field(default_factory=RunSection)
+
+    # `[testbed.<name>]` tables map to {name: Testbed}.
+    testbed: dict[str, Testbed] = Field(default_factory=dict)
+
+
+# --- Discovery --------------------------------------------------------------
+
+
+def discover_config_path(
+    explicit: os.PathLike[str] | str | None = None,
+    *,
+    environ: Mapping[str, str] = os.environ,
+    start_dir: os.PathLike[str] | str | None = None,
+) -> Path | None:
+    """Find the config file to load, highest priority first.
+
+    1. `explicit` (the `-c/--config PATH` flag) wins outright.
+    2. `DOTBOT_CONFIG` env var (an explicit path by another name).
+    3. The nearest `dotbot.toml`, searching the cwd and its parents (stopping at
+       a `.git` boundary) - so a per-experiment config "just works".
+    4. The user file `~/.dotbot/config.toml`.
+    5. None (caller uses built-in defaults).
+    """
+    if explicit:
+        return Path(explicit)
+    env_path = environ.get("DOTBOT_CONFIG")
+    if env_path:
+        return Path(env_path)
+
+    start = Path(start_dir or Path.cwd()).resolve()
+    for directory in (start, *start.parents):
+        candidate = directory / PROJECT_CONFIG_NAME
+        if candidate.is_file():
+            return candidate
+        if (directory / ".git").exists():
+            break
+
+    if USER_CONFIG_PATH.is_file():
+        return USER_CONFIG_PATH
+    return None
+
+
+def load_config(path: os.PathLike[str] | str | None) -> DotbotConfig:
+    """Load and validate a config file. `None` -> an empty config (all defaults).
+
+    Raises `ConfigError` (with the file path) on bad TOML, an unknown key, a
+    wrong-typed value, or an invalid connection string.
+    """
+    if path is None:
+        return DotbotConfig()
+    path = Path(path)
+    try:
+        with open(path, "rb") as handle:
+            data = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ConfigError(f"could not read config {path}: {exc}") from exc
+    try:
+        return DotbotConfig.model_validate(data)
+    except ValidationError as exc:
+        raise ConfigError(f"invalid config {path}:\n{exc}") from exc
+
+
+def load_discovered(
+    explicit: os.PathLike[str] | str | None = None,
+    *,
+    environ: Mapping[str, str] = os.environ,
+    start_dir: os.PathLike[str] | str | None = None,
+) -> tuple[DotbotConfig, Path | None]:
+    """Discover + load in one step. Returns (config, source_path or None)."""
+    path = discover_config_path(explicit, environ=environ, start_dir=start_dir)
+    return load_config(path), path
+
+
+# --- Testbed selection ------------------------------------------------------
+
+
+def select_testbed(
+    config: DotbotConfig,
+    *,
+    cli_name: str | None = None,
+    environ: Mapping[str, str] = os.environ,
+) -> tuple[Testbed | None, str | None]:
+    """Resolve the active testbed: `--testbed` > `DOTBOT_TESTBED` > default_testbed.
+
+    Returns (testbed, name), or (None, None) if none is selected. Raises
+    `ConfigError` if the selected name has no `[testbed.<name>]` entry.
+    """
+    name = cli_name or environ.get("DOTBOT_TESTBED") or config.default_testbed
+    if not name:
+        return None, None
+    if name not in config.testbed:
+        known = ", ".join(sorted(config.testbed)) or "(none defined)"
+        raise ConfigError(f"unknown testbed {name!r}; defined testbeds: {known}")
+    return config.testbed[name], name
+
+
+# --- Precedence resolution --------------------------------------------------
+
+
+def _env_candidates(section: str | None, key: str) -> tuple[str, ...]:
+    """Env-var names to check, in priority order (Cargo's mechanical mapping).
+
+    Sectioned key -> `DOTBOT_<SECTION>_<KEY>`, then the shared `DOTBOT_<KEY>`
+    alias. Top-level key -> just `DOTBOT_<KEY>`.
+    """
+    key_part = key.upper().replace("-", "_")
+    if section:
+        return (f"DOTBOT_{section.upper()}_{key_part}", f"DOTBOT_{key_part}")
+    return (f"DOTBOT_{key_part}",)
+
+
+def _coerce(raw: str, like: Any) -> Any:
+    """Coerce an env-var string to the type of `like` (the default)."""
+    if isinstance(like, bool):
+        return raw.strip().lower() in ("1", "true", "yes", "on")
+    if isinstance(like, int):
+        try:
+            return int(raw)
+        except ValueError as exc:
+            raise ConfigError(f"expected an integer, got {raw!r}") from exc
+    return raw
+
+
+def _file_value(
+    config: DotbotConfig | None,
+    section: str | None,
+    key: str,
+    testbed: Testbed | None,
+) -> Any:
+    """The value this key has in the file layer: section > testbed > top-level."""
+    if config is None:
+        return None
+    if section is not None:
+        section_obj = getattr(config, section, None)
+        value = getattr(section_obj, key, None)
+        if value is not None:
+            return value
+    if testbed is not None:
+        value = getattr(testbed, key, None)
+        if value is not None:
+            return value
+    return getattr(config, key, None)
+
+
+def resolve(
+    key: str,
+    *,
+    section: str | None = None,
+    flag: Any = None,
+    config: DotbotConfig | None = None,
+    testbed: Testbed | None = None,
+    default: Any = None,
+    environ: Mapping[str, str] = os.environ,
+) -> Any:
+    """Resolve one setting through the full precedence chain.
+
+    `flag` > env (`DOTBOT_<SECTION>_<KEY>`, then shared `DOTBOT_<KEY>`) >
+    file (section > testbed > top-level) > `default`.
+
+    `section` is one of `SECTIONS` for a per-namespace key, or `None` for a
+    top-level shared key (e.g. `conn`, `swarm_id`). Env values are coerced to
+    the type of `default`.
+    """
+    if flag is not None:
+        return flag
+    for name in _env_candidates(section, key):
+        if name in environ:
+            return _coerce(environ[name], default)
+    file_value = _file_value(config, section, key, testbed)
+    if file_value is not None:
+        return file_value
+    return default

--- a/dotbot/tests/test_config.py
+++ b/dotbot/tests/test_config.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: 2026-present Inria
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Headless tests for the unified config resolver (dotbot/config.py).
+
+Pure {flags, env, file} -> resolved value; no hardware, no network. Covers the
+precedence chain, discovery order, testbed selection, and strict validation.
+"""
+
+import pytest
+
+import dotbot.config as cfg
+
+# --- discovery --------------------------------------------------------------
+
+
+def test_discover_explicit_wins(tmp_path, monkeypatch):
+    explicit = tmp_path / "given.toml"
+    explicit.write_text("")
+    monkeypatch.setenv("DOTBOT_CONFIG", str(tmp_path / "env.toml"))
+    (tmp_path / cfg.PROJECT_CONFIG_NAME).write_text("")
+    assert cfg.discover_config_path(explicit, start_dir=tmp_path) == explicit
+
+
+def test_discover_env_var(tmp_path, monkeypatch):
+    env_file = tmp_path / "env.toml"
+    monkeypatch.setenv("DOTBOT_CONFIG", str(env_file))
+    assert (
+        cfg.discover_config_path(None, environ={"DOTBOT_CONFIG": str(env_file)})
+        == env_file
+    )
+
+
+def test_discover_project_cwd_upward(tmp_path):
+    root = tmp_path / "exp"
+    nested = root / "a" / "b"
+    nested.mkdir(parents=True)
+    project = root / cfg.PROJECT_CONFIG_NAME
+    project.write_text("")
+    found = cfg.discover_config_path(None, environ={}, start_dir=nested)
+    assert found == project
+
+
+def test_discover_stops_at_git_boundary(tmp_path, monkeypatch):
+    # A dotbot.toml above a .git boundary must NOT be picked up.
+    outer = tmp_path / "outer"
+    repo = outer / "repo"
+    sub = repo / "sub"
+    sub.mkdir(parents=True)
+    (outer / cfg.PROJECT_CONFIG_NAME).write_text("")  # above the boundary
+    (repo / ".git").mkdir()
+    monkeypatch.setattr(cfg, "USER_CONFIG_PATH", tmp_path / "nope.toml")
+    assert cfg.discover_config_path(None, environ={}, start_dir=sub) is None
+
+
+def test_discover_user_fallback(tmp_path, monkeypatch):
+    user = tmp_path / "home.toml"
+    user.write_text("")
+    monkeypatch.setattr(cfg, "USER_CONFIG_PATH", user)
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert cfg.discover_config_path(None, environ={}, start_dir=empty) == user
+
+
+def test_discover_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg, "USER_CONFIG_PATH", tmp_path / "missing.toml")
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert cfg.discover_config_path(None, environ={}, start_dir=empty) is None
+
+
+# --- loading + validation ---------------------------------------------------
+
+
+def test_load_none_is_empty():
+    config = cfg.load_config(None)
+    assert config.conn is None
+    assert config.testbed == {}
+
+
+def test_load_valid(tmp_path):
+    path = tmp_path / "dotbot.toml"
+    path.write_text(
+        """
+default_testbed = "inria"
+conn = "mqtts://broker.local:8883"
+swarm_id = "0001"
+
+[testbed.inria]
+conn = "mqtts://broker.inria.fr:8883"
+swarm_id = "0001"
+location = "Inria Paris"
+bots = 100
+
+[fw]
+board = "dotbot-v3"
+
+[run.controller]
+http_port = 8000
+"""
+    )
+    config = cfg.load_config(path)
+    assert config.default_testbed == "inria"
+    assert config.fw.board == "dotbot-v3"
+    assert config.run.controller.http_port == 8000
+    assert config.testbed["inria"].bots == 100
+
+
+def test_load_unknown_top_level_key_rejected(tmp_path):
+    path = tmp_path / "dotbot.toml"
+    path.write_text('swrm_id = "0001"\n')  # typo
+    with pytest.raises(cfg.ConfigError):
+        cfg.load_config(path)
+
+
+def test_load_unknown_section_key_rejected(tmp_path):
+    path = tmp_path / "dotbot.toml"
+    path.write_text('[fw]\nbord = "x"\n')  # typo in a section
+    with pytest.raises(cfg.ConfigError):
+        cfg.load_config(path)
+
+
+def test_load_bad_conn_rejected(tmp_path):
+    path = tmp_path / "dotbot.toml"
+    path.write_text('conn = "ftp://nope"\n')  # unrecognized scheme
+    with pytest.raises(cfg.ConfigError):
+        cfg.load_config(path)
+
+
+def test_load_accepts_valid_conn_forms(tmp_path):
+    path = tmp_path / "dotbot.toml"
+    path.write_text(
+        '[testbed.sim]\nconn = "simulator"\n'
+        '[testbed.cable]\nconn = "/dev/ttyACM0"\n'
+        '[testbed.mqtt]\nconn = "mqtts://h:8883"\n'
+    )
+    config = cfg.load_config(path)
+    assert set(config.testbed) == {"sim", "cable", "mqtt"}
+
+
+def test_load_bad_type_rejected(tmp_path):
+    path = tmp_path / "dotbot.toml"
+    path.write_text('[run.controller]\nhttp_port = "not-an-int"\n')
+    with pytest.raises(cfg.ConfigError):
+        cfg.load_config(path)
+
+
+# --- testbed selection ------------------------------------------------------
+
+
+def _two_testbeds():
+    return cfg.DotbotConfig(
+        default_testbed="inria",
+        testbed={
+            "inria": cfg.Testbed(swarm_id="0001"),
+            "laposte": cfg.Testbed(swarm_id="002a"),
+        },
+    )
+
+
+def test_select_testbed_cli_beats_env_and_default():
+    config = _two_testbeds()
+    tb, name = cfg.select_testbed(
+        config, cli_name="laposte", environ={"DOTBOT_TESTBED": "inria"}
+    )
+    assert name == "laposte"
+    assert tb.swarm_id == "002a"
+
+
+def test_select_testbed_env_beats_default():
+    config = _two_testbeds()
+    _, name = cfg.select_testbed(config, environ={"DOTBOT_TESTBED": "laposte"})
+    assert name == "laposte"
+
+
+def test_select_testbed_default():
+    config = _two_testbeds()
+    _, name = cfg.select_testbed(config, environ={})
+    assert name == "inria"
+
+
+def test_select_testbed_none_when_unset():
+    config = cfg.DotbotConfig()
+    assert cfg.select_testbed(config, environ={}) == (None, None)
+
+
+def test_select_testbed_unknown_raises():
+    config = _two_testbeds()
+    with pytest.raises(cfg.ConfigError):
+        cfg.select_testbed(config, cli_name="nope", environ={})
+
+
+# --- precedence resolution --------------------------------------------------
+
+
+def test_resolve_flag_wins():
+    config = cfg.DotbotConfig(conn="mqtts://file:8883")
+    got = cfg.resolve(
+        "conn",
+        flag="mqtts://flag:8883",
+        config=config,
+        environ={"DOTBOT_CONN": "mqtts://env:8883"},
+        default="mqtts://default:8883",
+    )
+    assert got == "mqtts://flag:8883"
+
+
+def test_resolve_env_beats_file_and_default():
+    config = cfg.DotbotConfig(swarm_id="file")
+    got = cfg.resolve(
+        "swarm_id",
+        config=config,
+        environ={"DOTBOT_SWARM_ID": "env"},
+        default="default",
+    )
+    assert got == "env"
+
+
+def test_resolve_sectioned_env_name():
+    got = cfg.resolve(
+        "board",
+        section="fw",
+        environ={"DOTBOT_FW_BOARD": "nrf5340dk-app"},
+        default="dotbot-v3",
+    )
+    assert got == "nrf5340dk-app"
+
+
+def test_resolve_shared_env_alias_for_section_key():
+    # A sectioned key falls back to the shared DOTBOT_<KEY> alias.
+    got = cfg.resolve(
+        "swarm_id", section="swarm", environ={"DOTBOT_SWARM_ID": "abcd"}, default="0000"
+    )
+    assert got == "abcd"
+
+
+def test_resolve_file_only_then_default():
+    config = cfg.DotbotConfig(log_level="debug")
+    assert (
+        cfg.resolve("log_level", config=config, environ={}, default="info") == "debug"
+    )
+    assert (
+        cfg.resolve("log_level", config=cfg.DotbotConfig(), environ={}, default="info")
+        == "info"
+    )
+
+
+def test_resolve_section_beats_top_level():
+    config = cfg.DotbotConfig(
+        swarm_id="top", swarm=cfg.SwarmSection(swarm_id="section")
+    )
+    got = cfg.resolve(
+        "swarm_id", section="swarm", config=config, environ={}, default="d"
+    )
+    assert got == "section"
+
+
+def test_resolve_testbed_beats_top_level():
+    config = cfg.DotbotConfig(conn="mqtts://top:8883")
+    tb = cfg.Testbed(conn="mqtts://inria:8883")
+    got = cfg.resolve("conn", config=config, testbed=tb, environ={}, default=None)
+    assert got == "mqtts://inria:8883"
+
+
+def test_resolve_section_beats_testbed():
+    # Documented order: section value > selected testbed > top-level.
+    config = cfg.DotbotConfig(swarm=cfg.SwarmSection(swarm_id="section"))
+    tb = cfg.Testbed(swarm_id="testbed")
+    got = cfg.resolve(
+        "swarm_id", section="swarm", config=config, testbed=tb, environ={}, default="d"
+    )
+    assert got == "section"
+
+
+def test_resolve_env_coercion_int():
+    got = cfg.resolve(
+        "http_port",
+        section="run",
+        environ={"DOTBOT_RUN_HTTP_PORT": "9000"},
+        default=8000,
+    )
+    assert got == 9000 and isinstance(got, int)
+
+
+def test_resolve_env_coercion_bool():
+    got = cfg.resolve(
+        "webbrowser",
+        section="run",
+        environ={"DOTBOT_RUN_WEBBROWSER": "true"},
+        default=False,
+    )
+    assert got is True
+
+
+def test_resolve_bad_int_env_raises():
+    with pytest.raises(cfg.ConfigError):
+        cfg.resolve(
+            "http_port", section="run", environ={"DOTBOT_HTTP_PORT": "x"}, default=8000
+        )


### PR DESCRIPTION
First phase of unifying the dotbot configuration into one file. Today config is
scattered across three overlapping surfaces - `run controller --config-path`,
`swarm -c` (actually swarmit's loader, wrapped), and `~/.dotbot/config.toml`'s
`[fw]` table - with three names for the network id (`swarm_id` / `network_id` /
`swarmit_network_id`) and an overloaded `-c` (build-config in `fw`/`device`,
config-file in `swarm`). This PR adds the pure resolver that a later phase will
wire the commands onto.

**What this adds** (`dotbot/config.py`):

- A pydantic schema mirroring the four-namespace CLI: top-level shared keys plus
  `[fw]` / `[device]` / `[swarm]` / `[run]` tables (with `[run.controller]` /
  `[run.gateway]` sub-tables) and `[testbed.<name>]` entries for the physical
  deployments you switch between. `extra='forbid'`, so a typo'd key fails loud
  at load instead of silently defaulting.
- Discovery: explicit `-c PATH` > `DOTBOT_CONFIG` > nearest `dotbot.toml`
  (cwd-upward, stops at a `.git` boundary) > `~/.dotbot/config.toml` > none.
- `select_testbed`: `--testbed` > `DOTBOT_TESTBED` > `default_testbed`; fails
  loud on an unknown name.
- `resolve()`: one precedence function - CLI flag > env
  (`DOTBOT_<SECTION>_<KEY>`, then a shared `DOTBOT_<KEY>` alias) > file
  (section > selected testbed > top-level) > built-in default.
- `conn` values are validated through the existing `parse_connection`, so the
  file path and the `--conn` flag share one validator and can't drift.

**No behavior change**: nothing imports the module yet - it's the inert core for
the upcoming wiring phase, so this is a safe standalone addition.

**Validation**: 29 new headless tests (`test_config.py`, 96% module coverage) -
precedence permutations, discovery order, testbed selection, strict unknown-key
rejection, and env coercion. Full suite green (315 passed); pre-commit clean.