### PR TITLE
doc: onboarding setup fixes from testing (+ #267 web-UI guard)

### DIFF
--- a/doc/cli/device.md
+++ b/doc/cli/device.md
@@ -15,6 +15,11 @@ instead. To build the `.hex` first, see [`fw`](fw.md).
 UART↔MQTT bridge process is a different thing - that's [`run gateway`](run.md).
 ```
 
+```{note}
+`dotbot device` drives **`nrfjprog`** (Nordic's nRF Command Line Tools), not
+`nrfutil` - install it and put its `bin/` on your `PATH` before flashing.
+```
+
 ## Commands
 
 | Command | What it does |
@@ -41,6 +46,10 @@ dotbot device flash dotbot -s 77
 `-b/--board` selects the **chip family and core** to program. The nrfjprog family
 and coprocessor are derived from it: nRF52 boards → `-f NRF52`, no coprocessor;
 nRF5340 → `-f NRF53` with `CP_APPLICATION`, or `CP_NETWORK` for a `*-net` board.
+
+`-b` only sets the family/core nrfjprog is *told* to program; the CLI doesn't
+read it back from the attached chip. Make sure the cabled board matches `-b` -
+e.g. don't flash an nRF53 image onto a connected nRF52 (or vice versa).
 
 ```bash
 # Gateway onto an nRF52840-DK (device flash picks -f NRF52 from the board)

--- a/doc/cli/fw.md
+++ b/doc/cli/fw.md
@@ -10,15 +10,33 @@ non-secure (NS) flavor that runs inside the swarm sandbox host.
 ## Setup
 
 `dotbot fw` builds from a local `DotBot-firmware` checkout via SEGGER Embedded
-Studio (SES). Point the CLI at the checkout (otherwise it looks for
-`./DotBot-firmware/`); SES is auto-resolved.
+Studio (SES), so it needs to find both. The checkout defaults to
+`./DotBot-firmware/`; SES is auto-detected only on macOS (a standard
+`/Applications/SEGGER/` install), so on Linux/Windows builds fail with
+"SEGGER Embedded Studio ... wasn't found" until you point at it.
 
-```bash
-export DOTBOT_FIRMWARE_REPO=/path/to/DotBot-firmware
-# or persist it once in ~/.dotbot/config.toml:
-#   [fw]
-#   firmware_repo = "/path/to/DotBot-firmware"
+Your firmware checkout is per-project, so set it in the project's `./dotbot.toml`
+(or export `DOTBOT_FIRMWARE_REPO`):
+
+```toml
+# ./dotbot.toml  (per project)
+[fw]
+firmware_repo = "/path/to/DotBot-firmware"
 ```
+
+Your SES install rarely changes, so set it once per machine in
+`~/.dotbot/config.toml`:
+
+```toml
+# ~/.dotbot/config.toml  (once per machine)
+[fw]
+segger_dir = "/path/to/SEGGER Embedded Studio X.YY"
+```
+
+> **First SES build needs the nRF + CMSIS_5 packages.** A fresh SES install has
+> no chip headers, so the build fails with `fatal error: 'nrf.h' file not found`.
+> In SES, open **Tools → Package Manager** and install the **nRF** and
+> **CMSIS_5** packages (`nrf.h` ships in the nRF one). One-time per SES install.
 
 ## Which command do I want?
 

--- a/doc/hardware/index.md
+++ b/doc/hardware/index.md
@@ -10,6 +10,16 @@ Three pieces make up a working setup:
 - **The gateway** - an nRF5340-DK that bridges your computer to the swarm over the air.
 - **A Lighthouse 2 base station** - for indoor localization (optional, per-experiment).
 
+## Cables and connectors
+
+What to have on hand (the two USB cables are the ones you'll reach for most):
+
+| Cable / connector | For |
+|---|---|
+| **USB-C to USB-A (or USB-C)** | Flash and power the DotBot v3 (its USB-C port, J2). |
+| **micro-USB to USB-A (or USB-C)** | The nRF5340-DK gateway's on-board J-Link. |
+| **Barrel-jack charger** (2.5 mm, 6-18 V) | Charges the DotBot v3 supercap (J4); free-roaming only. |
+
 ## DotBot v3 - the robot
 
 The robot has two connectors you'll use:

--- a/doc/index.md
+++ b/doc/index.md
@@ -31,6 +31,9 @@ own code - one bot, or a swarm of hundreds. Pick a starting point:
 - **Extend the platform** - every command and flag is in the
   [CLI reference](cli/index.md); the firmware flows live under [`fw`](cli/fw.md)
   and [`device`](cli/device.md).
+- **Before flashing hardware** - the simulator and driving an existing swarm
+  need only Python; building and cable-flashing firmware also need SES and the
+  nRF Command Line Tools (`nrfjprog`). See **Prerequisites** below before you start.
 ```
 
 ```{include} ../README.md

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -35,8 +35,10 @@ directory. Discovery looks only at the cwd - it does not walk up to parent
 directories, so the active config is always unambiguous.
 
 `~/.dotbot/config.toml` (4) is the per-machine fallback for settings you set
-once and want everywhere - typically `[fw].segger_dir` and `[fw].firmware_repo`.
-Every command, including `dotbot fw`, reads through this same resolver.
+once and want everywhere - typically `[fw].segger_dir`, since the SES install
+path rarely changes. Per-project settings like `[fw].firmware_repo` belong in
+the project's `./dotbot.toml` instead. Every command, including `dotbot fw`,
+reads through this same resolver.
 
 ## Precedence
 

--- a/doc/reference/troubleshooting.md
+++ b/doc/reference/troubleshooting.md
@@ -12,3 +12,22 @@ to the controller, so the map and joystick never come alive. Turn it off:
 3. Reload the web UI.
 
 Chromium-based browsers (Chrome, Edge, Brave) are unaffected.
+
+## Web UI is missing (frontend build not found)
+
+Starting the controller or simulator logs:
+
+```
+Frontend build not found at .../dotbot/frontend/build; the web UI will be unavailable.
+```
+
+The React web UI ships inside the published wheel but is **not** built by a
+plain source checkout, so a git clone (or a wheel-less install) has no
+`dotbot/frontend/build/`. The controller and its REST/WebSocket API still run -
+only the browser UI is unavailable. Fixes:
+
+- **From PyPI** - install the wheel, which bundles the UI: `pip install --pre pydotbot`.
+- **From a git checkout** - build the UI once: `cd dotbot/frontend && npm install && npm run build`.
+
+On a version without this check, the same cause surfaces as a startup crash,
+`RuntimeError: Directory '.../dotbot/frontend/build' does not exist`.

--- a/dotbot/server.py
+++ b/dotbot/server.py
@@ -364,4 +364,14 @@ async def ws_dotbots(websocket: WebSocket):
 
 # Mount static files after all routes are defined
 FRONTEND_DIR = os.path.join(os.path.dirname(__file__), "frontend", "build")
-api.mount("/PyDotBot", StaticFiles(directory=FRONTEND_DIR, html=True), name="PyDotBot")
+if os.path.isdir(FRONTEND_DIR):
+    api.mount(
+        "/PyDotBot", StaticFiles(directory=FRONTEND_DIR, html=True), name="PyDotBot"
+    )
+else:
+    LOGGER.warning(
+        "Frontend build not found at %s; the web UI will be unavailable. "
+        "Install the published wheel (pip install --pre pydotbot) or build the "
+        "frontend: cd dotbot/frontend && npm install && npm run build",
+        FRONTEND_DIR,
+    )


### PR DESCRIPTION
Fixes surfaced by a first-time setup of the platform, plus the simulator crash in #267.

## #267 - controller/simulator crash when there is no frontend build
`dotbot run simulator -w` (and `run controller`) crashed at import time with `RuntimeError: Directory '.../dotbot/frontend/build' does not exist` on installs without a built React bundle (a source checkout, or a wheel that did not bundle the UI). `server.py` now skips the static mount when the build is absent and logs an actionable warning, so the REST/WebSocket API still serves headless. A matching Troubleshooting entry covers both triggers. Validated: 28 server tests pass; the missing-build path no longer raises.

## Onboarding docs (from the setup feedback)
- **Build-from-source prerequisites**: SES auto-detection is macOS-only, so the `fw` page now explains setting `segger_dir` on Linux/Windows, and documents installing the SES Package Manager `nRF` + `CMSIS_5` packages (the `nrf.h file not found` failure).
- **Config placement**: `firmware_repo` is per-project (`./dotbot.toml`); only `segger_dir` is machine-wide (`~/.dotbot/config.toml`). Corrected on both the `fw` page and the configuration reference.
- **Flashing prerequisite**: the `device` page states `dotbot device` drives `nrfjprog` (nRF Command Line Tools), not nrfutil, with a non-asserting board-match caution.
- **Discoverability**: a prerequisites pointer on the docs landing page and a cables/connectors checklist on the hardware page.

## Deliberately not changed
- The SES "license-free CMake/GCC build path is planned" note is accurate - no GCC firmware build exists yet (only an unmerged PoC), so it stays.
- "Wrong board type silently fails": left as a doc caution only. The chip family comes from `-b/--board` and is passed straight to `nrfjprog -f` with no readback of the attached chip; whether nrfjprog errors on a mismatch or mis-flashes quietly is hardware behavior, not something to assert from code. Worth a bench check - if it does not fail loudly, a probe-family readback + abort is the fix.

Closes #267.