### PR TITLE
dotbot/cli: config inspection + --swarm-id follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,22 +118,6 @@ Commands:
 
 Every command and flag is documented in the [CLI reference][cli-doc].
 
-## Configuration
-
-Most commands share a couple of settings - your gateway connection and swarm
-id. Keep them in one `dotbot.toml` instead of repeating flags:
-
-```bash
-dotbot config init --conn mqtts://broker:8883 --swarm-id 1234  # write ./dotbot.toml
-dotbot config show   # the resolved config + which file it came from
-dotbot config path   # just the file path
-```
-
-`dotbot` reads `./dotbot.toml` (current directory), falling back to
-`~/.dotbot/config.toml`; a `-c/--config FILE` flag or `DOTBOT_*` env vars
-override it for a single run. Full schema: the
-[configuration reference][config-doc].
-
 ## Quickstart - one bot
 
 Build and flash firmware for a single dotbot:

--- a/README.md
+++ b/README.md
@@ -113,9 +113,26 @@ Commands:
   device  One connected device (cable/probe): flash an app/role, read info.
   swarm   The fleet over the air: status, start/stop, OTA flash, monitor.
   run     Host-side processes: controller, gateway, simulator, calibration, demos, teleop.
+  config  Show the resolved config and where it came from; scaffold one with init.
 ```
 
 Every command and flag is documented in the [CLI reference][cli-doc].
+
+## Configuration
+
+Most commands share a couple of settings - your gateway connection and swarm
+id. Keep them in one `dotbot.toml` instead of repeating flags:
+
+```bash
+dotbot config init --conn mqtts://broker:8883 --swarm-id 1234  # write ./dotbot.toml
+dotbot config show   # the resolved config + which file it came from
+dotbot config path   # just the file path
+```
+
+`dotbot` reads `./dotbot.toml` (current directory), falling back to
+`~/.dotbot/config.toml`; a `-c/--config FILE` flag or `DOTBOT_*` env vars
+override it for a single run. Full schema: the
+[configuration reference][config-doc].
 
 ## Quickstart - one bot
 

--- a/doc/cli/config.md
+++ b/doc/cli/config.md
@@ -1,0 +1,54 @@
+# `dotbot config` - inspect and scaffold the config
+
+`dotbot` reads a `dotbot.toml` so commands don't repeat shared settings - your
+gateway connection, swarm id, firmware paths. `config` scaffolds that file and
+shows you what the CLI actually resolved. For the full file format - every key,
+deployments, the precedence rules - see the
+[configuration reference](../reference/configuration.md).
+
+## Which command do I want?
+
+| Goal | Command |
+|---|---|
+| Write a starter `dotbot.toml` you can edit | `dotbot config init` |
+| See the merged, effective config + which file it came from | `dotbot config show` |
+| Print just the resolved config-file path | `dotbot config path` |
+
+## `init`
+
+Writes a minimal `./dotbot.toml` - a one-line pointer to the docs, plus any keys
+you pre-fill. `--global` writes your per-machine `~/.dotbot/config.toml` instead;
+`-f/--force` overwrites an existing file.
+
+```bash
+dotbot config init                                             # commented starter in ./dotbot.toml
+dotbot config init --conn mqtts://broker:8883 --swarm-id 1234  # pre-fill the two common keys
+dotbot config init --global                                    # ~/.dotbot/config.toml
+```
+
+> MQTT credentials are never file keys - set `DOTBOT_MQTT_USER` /
+> `DOTBOT_MQTT_PASS` in the environment.
+
+## `show` / `path`
+
+`show` prints the source file, the selected deployment, and the resolved config
+as TOML - only the keys actually set, not the full schema. `path` prints just
+the file path (or notes that built-in defaults are in use). Both are read-only;
+there is no per-key `set` - edit the file, it's yours.
+
+```bash
+dotbot config show
+dotbot config path
+```
+
+## Where the config comes from
+
+`dotbot` uses the first of: a `-c/--config FILE` flag (or `DOTBOT_CONFIG`), a
+`dotbot.toml` in the current directory, then `~/.dotbot/config.toml`. A flag or a
+`DOTBOT_*` env var overrides the file for a single run. The full precedence chain
+is in the [configuration reference](../reference/configuration.md#precedence).
+
+## See also
+
+- [Configuration reference](../reference/configuration.md) - the file format, every key, deployments, precedence.
+- [`dotbot fw`](fw.md) - reads its `[fw]` keys (`segger_dir`, `firmware_repo`) from this same config.

--- a/doc/cli/device.md
+++ b/doc/cli/device.md
@@ -90,15 +90,15 @@ named release into `./artifacts/` if it isn't cached.
 
 ```bash
 # nRF5340-DK → swarm gateway
-dotbot device flash-mari-gateway -n 0100 -f 0.8.0rc1 -s 10
+dotbot device flash-mari-gateway --swarm-id 0100 -f 0.8.0rc1 -s 10
 
 # DotBot v3 → swarm sandbox host (the firmware that runs OTA apps)
-dotbot device flash-swarmit-sandbox -n 0100 -f 0.8.0rc1 -s 77
+dotbot device flash-swarmit-sandbox --swarm-id 0100 -f 0.8.0rc1 -s 77
 ```
 
 | Flag | `flash-mari-gateway` | `flash-swarmit-sandbox` |
 |---|---|---|
-| `-n, --network-id` | 16-bit hex net id (required) | 16-bit hex net id (required) |
+| `--swarm-id` | 16-bit hex swarm id (or from config) | 16-bit hex swarm id (or from config) |
 | `-f, --fw-version` | release to flash (required) | release to flash (required) |
 | `-s, --sn-starting-digits` | J-Link serial prefix | J-Link serial prefix |
 | `-l, --calibration` | - | optional LH2 calibration file to bake in |

--- a/doc/cli/index.md
+++ b/doc/cli/index.md
@@ -6,6 +6,7 @@ fw
 device
 swarm
 run
+config
 ```
 
 One CLI for the whole DotBot workflow: build firmware, flash one board, control a
@@ -26,6 +27,9 @@ dotbot --help
 | [`device`](device.md) | Flash one cabled board and read its info. | A DotBot or DK is plugged into your USB port right now. |
 | [`swarm`](swarm.md) | Drive the whole fleet over the air - status, OTA flash, start/stop, monitor. | You're operating many provisioned bots through a gateway. |
 | [`run`](run.md) | Start host processes on your computer - controller, gateway bridge, simulator, demos, teleop. | You need the web UI, a gateway bridge, the simulator, or a demo. |
+
+Beyond the four namespaces, [`config`](config.md) scaffolds and inspects the
+shared `dotbot.toml` the other commands read their defaults from.
 
 ## Which one do I want?
 
@@ -60,6 +64,7 @@ A few signposts so the namespaces don't blur together:
 - [`device`](device.md) - flash and inspect one cabled board.
 - [`swarm`](swarm.md) - run experiments across the fleet.
 - [`run`](run.md) - launch the controller, gateway bridge, simulator, and demos.
+- [`config`](config.md) - scaffold and inspect the shared `dotbot.toml`.
 
 Two end-to-end walkthroughs put these together: [build and flash one
 board](device.md), and [operate a swarm over the air](swarm.md).

--- a/doc/cli/swarm.md
+++ b/doc/cli/swarm.md
@@ -25,8 +25,8 @@ USB-C (the DotBot v3 has an on-board programmer - no separate J-Link needed).
 Details and chip caveats live in [`device`](device.md).
 
 ```bash
-dotbot device flash-mari-gateway      -n 1234 -s 10 -f 0.8.0rc1   # a DK -> gateway, net id 0x1234
-dotbot device flash-swarmit-sandbox -n 1234 -s 77 -f 0.8.0rc1   # each bot -> sandbox host
+dotbot device flash-mari-gateway      --swarm-id 1234 -s 10 -f 0.8.0rc1   # a DK -> gateway, net id 0x1234
+dotbot device flash-swarmit-sandbox --swarm-id 1234 -s 77 -f 0.8.0rc1   # each bot -> sandbox host
 ```
 
 ## 2. Start the host bridge

--- a/doc/hardware/index.md
+++ b/doc/hardware/index.md
@@ -61,7 +61,7 @@ host to the swarm radio.
 
 ```bash
 # flash the gateway role onto a DK (writes the network id + both cores)
-dotbot device flash-mari-gateway -n 0100 -f 0.8.0rc1 -s 10
+dotbot device flash-mari-gateway --swarm-id 0100 -f 0.8.0rc1 -s 10
 
 # then run the host-side UART<->MQTT bridge
 dotbot run gateway

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -17,6 +17,9 @@ pass `--conn` / `--swarm-id` to pre-fill the two most common keys:
 dotbot config init --conn mqtts://broker:8883 --swarm-id 1234
 ```
 
+This page is the file-format reference. For the `config` command itself
+(`init` / `show` / `path`), see [`dotbot config`](../cli/config.md).
+
 ## Where the file comes from
 
 `dotbot` looks in this order and uses the first hit:

--- a/dotbot/cli/config_cmd.py
+++ b/dotbot/cli/config_cmd.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 import click
+import tomlkit
 
 from dotbot.config import USER_CONFIG_PATH
 
@@ -108,30 +109,12 @@ def path(ctx):
         click.echo(str(config_path))
 
 
-def _dump_lines(prefix: str, value: Any) -> list[str]:
-    """Render `value` as `key = repr` lines, skipping None, recursing tables.
-
-    Pydantic sections become nested `[section]` / `[section.sub]` tables;
-    scalar fields print as `key = value` with the value quoted for strings.
-    """
-    lines: list[str] = []
-    nested: list[str] = []
-    for field, item in value.items():
-        if item is None or item == {}:
-            continue
-        if isinstance(item, dict):
-            header = f"{prefix}.{field}" if prefix else field
-            inner = _dump_lines(header, item)
-            if not inner:
-                continue
-            nested.append("")
-            nested.append(f"[{header}]")
-            nested.extend(inner)
-        elif isinstance(item, str):
-            lines.append(f"{field} = {item!r}")
-        else:
-            lines.append(f"{field} = {item}")
-    return lines + nested
+def _prune(value: Any) -> Any:
+    """Recursively drop None values and empty tables so only set keys remain."""
+    if isinstance(value, dict):
+        pruned = {k: _prune(v) for k, v in value.items() if v is not None}
+        return {k: v for k, v in pruned.items() if v != {}}
+    return value
 
 
 @cmd.command()
@@ -157,15 +140,14 @@ def show(ctx):
         click.echo("(no config loaded)")
         return
 
-    # exclude_none drops every unset Optional so the dump shows only what the
-    # file explicitly set (matches the resolver's "unset vs default" model).
-    data = config.model_dump(exclude_none=True)
-    lines = _dump_lines("", data)
-    if not lines:
+    # Prune unset Optionals so the dump shows only what the file explicitly set
+    # (matches the resolver's "unset vs default" model), then render via tomlkit
+    # so the output is real, round-trippable TOML.
+    data = _prune(config.model_dump())
+    if not data:
         if config_path is None:
             click.echo("No config file found. Create one with:  dotbot config init")
         else:
             click.echo("(the file sets nothing yet; all built-in defaults)")
         return
-    for line in lines:
-        click.echo(line)
+    click.echo(tomlkit.dumps(data).rstrip())

--- a/dotbot/cli/deployment_cmd.py
+++ b/dotbot/cli/deployment_cmd.py
@@ -10,7 +10,6 @@ defined by a `[deployment.<name>]` table in the config file. You *select* one
 command rather than a hand edit. `list` / `show` are read-only inspectors.
 """
 
-import re
 import tomllib
 from pathlib import Path
 
@@ -101,36 +100,16 @@ def show(ctx, name):
         click.echo(f"  {field}: {value}")
 
 
-# A `default_deployment = ...` line, active or commented-out, so `use` can
-# rewrite it in place and leave everything else (comments included) intact.
-_ACTIVE_DEFAULT_RE = re.compile(r"^\s*default_deployment\s*=")
-_ANY_DEFAULT_RE = re.compile(r"^\s*#?\s*default_deployment\s*=")
-
-
 def _set_default_deployment(path: Path, name: str) -> None:
     """Write `default_deployment = "<name>"` into `path`, preserving the rest.
 
-    Replaces the existing `default_deployment` line (an active one first, else
-    a commented-out one like the `config init` starter ships); when neither
-    exists, inserts the key before the first `[table]` header so it stays a
-    valid top-level TOML key.
+    tomlkit round-trips the document, so existing comments and structure stay
+    intact; it auto-places a new top-level key before the first `[table]` so the
+    result is valid TOML whether or not the key already existed.
     """
-    new_line = f'default_deployment = "{name}"'
-    lines = path.read_text().splitlines()
-
-    active = [i for i, line in enumerate(lines) if _ACTIVE_DEFAULT_RE.match(line)]
-    any_match = [i for i, line in enumerate(lines) if _ANY_DEFAULT_RE.match(line)]
-    target = active[0] if active else (any_match[0] if any_match else None)
-
-    if target is not None:
-        lines[target] = new_line
-    else:
-        insert_at = next(
-            (i for i, line in enumerate(lines) if line.lstrip().startswith("[")),
-            len(lines),
-        )
-        lines.insert(insert_at, new_line)
-    path.write_text("\n".join(lines) + "\n")
+    doc = tomlkit.parse(path.read_text())
+    doc["default_deployment"] = name
+    path.write_text(tomlkit.dumps(doc))
 
 
 @cmd.command()

--- a/dotbot/cli/device.py
+++ b/dotbot/cli/device.py
@@ -112,10 +112,9 @@ def _sn_option(f):
 
 @cmd.command(name="flash-swarmit-sandbox")
 @click.option(
-    "--network-id",
-    "-n",
+    "--swarm-id",
     default=None,
-    help="16-bit hex network id (e.g. 0100); defaults to your deployment's swarm_id.",
+    help="16-bit hex swarm id (e.g. 0100); defaults to your config's swarm_id.",
 )
 @click.option(
     "--calibration",
@@ -128,7 +127,7 @@ def _sn_option(f):
 @_sn_option
 @click.pass_context
 def flash_swarmit_sandbox(
-    ctx, network_id, calibration_path, fw_version, sn_starting_digits
+    ctx, swarm_id, calibration_path, fw_version, sn_starting_digits
 ):
     """Turn a DotBot v3 into a swarm sandbox host (was `provision -d dotbot-v3`).
 
@@ -138,14 +137,14 @@ def flash_swarmit_sandbox(
     """
     from dotbot.firmware.flash import flash_role, normalize_network_id
 
-    network_id = from_config(ctx, "network_id", "swarm_id", None)
-    if network_id is None:
+    swarm_id = from_config(ctx, "swarm_id", "swarm_id", None)
+    if swarm_id is None:
         raise click.ClickException(
-            "no network id: pass -n/--network-id, or set swarm_id (or a "
+            "no swarm id: pass --swarm-id, or set swarm_id (or a "
             "deployment) in your config."
         )
     ensure_nrfjprog()
-    net_id = normalize_network_id(network_id)
+    net_id = normalize_network_id(swarm_id)
     flash_role(
         "dotbot-v3",
         net_id=net_id,
@@ -158,15 +157,14 @@ def flash_swarmit_sandbox(
 
 @cmd.command(name="flash-mari-gateway")
 @click.option(
-    "--network-id",
-    "-n",
+    "--swarm-id",
     default=None,
-    help="16-bit hex network id (e.g. 0100); defaults to your deployment's swarm_id.",
+    help="16-bit hex swarm id (e.g. 0100); defaults to your config's swarm_id.",
 )
 @_fw_version_option
 @_sn_option
 @click.pass_context
-def flash_mari_gateway(ctx, network_id, fw_version, sn_starting_digits):
+def flash_mari_gateway(ctx, swarm_id, fw_version, sn_starting_digits):
     """Turn an nRF5340-DK into the swarm gateway (was `provision -d gateway`).
 
     Flashes the Mari gateway firmware (both cores) + writes the network
@@ -175,14 +173,14 @@ def flash_mari_gateway(ctx, network_id, fw_version, sn_starting_digits):
     """
     from dotbot.firmware.flash import flash_role, normalize_network_id
 
-    network_id = from_config(ctx, "network_id", "swarm_id", None)
-    if network_id is None:
+    swarm_id = from_config(ctx, "swarm_id", "swarm_id", None)
+    if swarm_id is None:
         raise click.ClickException(
-            "no network id: pass -n/--network-id, or set swarm_id (or a "
+            "no swarm id: pass --swarm-id, or set swarm_id (or a "
             "deployment) in your config."
         )
     ensure_nrfjprog()
-    net_id = normalize_network_id(network_id)
+    net_id = normalize_network_id(swarm_id)
     flash_role(
         "gateway",
         net_id=net_id,

--- a/dotbot/cli/main.py
+++ b/dotbot/cli/main.py
@@ -83,8 +83,8 @@ _SUBCOMMANDS = (
     type=click.Path(dir_okay=False),
     default=None,
     help=(
-        "Config file to use (default: the nearest ./dotbot.toml, searching up "
-        "from the cwd)."
+        "Config file to use (default: a dotbot.toml in the current directory, "
+        "else ~/.dotbot/config.toml)."
     ),
 )
 @click.option(

--- a/dotbot/tests/test_device.py
+++ b/dotbot/tests/test_device.py
@@ -57,19 +57,21 @@ def test_flash_mari_gateway_rejects_calibration(runner):
     # Passing it is an unknown-option error.
     bad = runner.invoke(
         device_cmd,
-        ["flash-mari-gateway", "-n", "1234", "-f", "0.8.0rc1", "-l", "x.out"],
+        ["flash-mari-gateway", "--swarm-id", "1234", "-f", "0.8.0rc1", "-l", "x.out"],
     )
     assert bad.exit_code != 0
 
 
-def test_flash_swarmit_sandbox_requires_network_id_and_version(runner):
-    """-n and -f are both required for flash-swarmit-sandbox."""
+def test_flash_swarmit_sandbox_requires_swarm_id_and_version(runner):
+    """--swarm-id and -f are both required for flash-swarmit-sandbox."""
     assert (
         runner.invoke(device_cmd, ["flash-swarmit-sandbox", "-f", "0.8.0rc1"]).exit_code
         != 0
     )
     assert (
-        runner.invoke(device_cmd, ["flash-swarmit-sandbox", "-n", "1234"]).exit_code
+        runner.invoke(
+            device_cmd, ["flash-swarmit-sandbox", "--swarm-id", "1234"]
+        ).exit_code
         != 0
     )
 
@@ -91,7 +93,7 @@ def test_flash_swarmit_sandbox_calls_engine(runner, _no_nrfjprog_gate, monkeypat
     monkeypatch.setattr("dotbot.firmware.flash.flash_role", fake_flash_role)
     result = runner.invoke(
         device_cmd,
-        ["flash-swarmit-sandbox", "-n", "0100", "-f", "0.8.0rc1", "-s", "77"],
+        ["flash-swarmit-sandbox", "--swarm-id", "0100", "-f", "0.8.0rc1", "-s", "77"],
     )
     assert result.exit_code == 0, result.output
     assert calls["role"] == "dotbot-v3"
@@ -109,7 +111,7 @@ def test_flash_mari_gateway_calls_engine_with_gateway_role(
         lambda role, **kw: calls.update(role=role, kw=kw),
     )
     result = runner.invoke(
-        device_cmd, ["flash-mari-gateway", "-n", "1234", "-f", "0.8.0rc1"]
+        device_cmd, ["flash-mari-gateway", "--swarm-id", "1234", "-f", "0.8.0rc1"]
     )
     assert result.exit_code == 0, result.output
     assert calls["role"] == "gateway"
@@ -117,7 +119,7 @@ def test_flash_mari_gateway_calls_engine_with_gateway_role(
     assert "calibration_path" not in calls["kw"]
 
 
-# ── network id defaults from the selected deployment's swarm_id ─────────
+# ── swarm id defaults from the selected deployment's swarm_id ─────────
 
 
 def _write_cfg(tmp_path, text):
@@ -129,7 +131,7 @@ def _write_cfg(tmp_path, text):
 def test_flash_mari_gateway_net_id_from_deployment(
     runner, _no_nrfjprog_gate, tmp_path, monkeypatch
 ):
-    """No -n + a selected deployment -> net_id derived from its swarm_id."""
+    """No --swarm-id + a selected deployment -> net_id derived from its swarm_id."""
     from dotbot.cli.main import cli
 
     calls = {}
@@ -153,7 +155,7 @@ def test_flash_mari_gateway_net_id_from_deployment(
 def test_flash_mari_gateway_explicit_net_id_overrides_deployment(
     runner, _no_nrfjprog_gate, tmp_path, monkeypatch
 ):
-    """An explicit -n beats the deployment's swarm_id."""
+    """An explicit --swarm-id beats the deployment's swarm_id."""
     from dotbot.cli.main import cli
 
     calls = {}
@@ -172,7 +174,7 @@ def test_flash_mari_gateway_explicit_net_id_overrides_deployment(
             str(cfg),
             "device",
             "flash-mari-gateway",
-            "-n",
+            "--swarm-id",
             "0099",
             "-f",
             "0.8.0rc1",
@@ -182,14 +184,14 @@ def test_flash_mari_gateway_explicit_net_id_overrides_deployment(
     assert calls["kw"]["net_id"] == (0x0099, "0099")
 
 
-def test_flash_mari_gateway_no_net_id_no_config_errors(runner, _no_nrfjprog_gate):
-    """No -n and no swarm_id/deployment -> a clean ClickException, not a crash."""
+def test_flash_mari_gateway_no_swarm_id_no_config_errors(runner, _no_nrfjprog_gate):
+    """No --swarm-id and no swarm_id/deployment -> a clean ClickException, not a crash."""
     from dotbot.cli.main import cli
 
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ["device", "flash-mari-gateway", "-f", "0.8.0rc1"])
     assert result.exit_code != 0
-    assert "no network id" in result.output
+    assert "no swarm id" in result.output
 
 
 def test_flash_swarmit_sandbox_net_id_from_deployment(


### PR DESCRIPTION
## Summary

Review follow-ups on the unified-config work (#266), all on the CLI inspection surface.

- `config show` and `deployment use` now go through tomlkit instead of a hand-rolled `repr()` emitter and a regex line-rewriter. `config show` output is now real, round-trippable TOML; `deployment use` preserves comments and structure when it rewrites `default_deployment`.
- The root `-c/--config` help no longer claims it walks up from the cwd. Discovery is cwd-only (then `~/.dotbot/config.toml`); the help now says so.
- The device-flash flag `--network-id`/`-n` is renamed to `--swarm-id` to match the rest of the CLI surface ahead of the freeze. It is long-only: `-s` is already `--sn-starting-digits` on these commands. This is the user-facing flag only; the firmware-side network identity is untouched.

## Test plan

- [x] `pytest dotbot/tests` (382 passed)
- [x] black / isort / ruff clean
- [ ] sanity-check `dotbot config show` / `dotbot deployment use` against a real `dotbot.toml`